### PR TITLE
Can we avoid the second dep in the consumer's dependenices?

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -96,7 +96,6 @@
     "extends": "../package.json"
   },
   "dependencies": {
-    "@universal-ember/kolay-ui": "workspace:^",
     "@universal-ember/test-support": "^0.0.0",
     "ember-async-data": "^1.0.3",
     "ember-cached-decorator-polyfill": "^1.0.2",
@@ -107,9 +106,6 @@
   },
   "dependenciesMeta": {
     "kolay": {
-      "injected": true
-    },
-    "@universal-ember/kolay-ui": {
       "injected": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:node": "vitest --run"
   },
   "dependencies": {
+    "@universal-ember/kolay-ui": "workspace:^",
     "@tsconfig/ember": "^3.0.3",
     "@zamiell/typedoc-plugin-not-exported": "^0.2.0",
     "common-tags": "^1.8.2",
@@ -179,7 +180,6 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@glint/template": "^1.3.0",
-    "@universal-ember/kolay-ui": "workspace:^",
     "ember-modifier": "^4.1.0",
     "ember-primitives": "^0.11.3",
     "ember-repl": "3.0.0-beta.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2617,7 +2617,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/macros': 1.13.5(@glint/template@1.3.0)
+      '@embroider/macros': 1.14.0(@glint/template@1.3.0)
       '@glint/environment-ember-loose': 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
       '@glint/template': 1.3.0
       broccoli-funnel: 3.0.8
@@ -2639,7 +2639,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/macros': 1.13.5(@glint/template@1.3.0)
+      '@embroider/macros': 1.14.0(@glint/template@1.3.0)
       '@glint/template': 1.3.0
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@tsconfig/ember':
         specifier: ^3.0.3
         version: 3.0.4
+      '@universal-ember/kolay-ui':
+        specifier: workspace:^
+        version: file:ui(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-modifier@4.1.0)(ember-primitives@0.11.3)(ember-repl@3.0.0)(ember-resources@7.0.0)(ember-source@5.5.0)(reactiveweb@1.2.2)(tracked-built-ins@3.3.0)
       '@zamiell/typedoc-plugin-not-exported':
         specifier: ^0.2.0
         version: 0.2.0(typedoc@0.25.10)
@@ -76,9 +79,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.0.1
         version: 7.1.0(eslint@8.57.0)(typescript@5.3.3)
-      '@universal-ember/kolay-ui':
-        specifier: workspace:^
-        version: file:ui(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-modifier@4.1.0)(ember-primitives@0.11.3)(ember-repl@3.0.0)(ember-resources@7.0.0)(ember-source@5.5.0)(reactiveweb@1.2.2)(tracked-built-ins@3.3.0)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -90,13 +90,13 @@ importers:
         version: 0.11.3(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-modifier@4.1.0)(ember-resources@7.0.0)(ember-source@5.5.0)
       ember-repl:
         specifier: ^3.0.0
-        version: 3.0.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-resources@7.0.0)(ember-source@5.5.0)(reactiveweb@1.2.2)
+        version: 3.0.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-resources@7.0.0)(ember-source@5.5.0)(reactiveweb@1.2.2)
       ember-resources:
         specifier: ^7.0.0
         version: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
       ember-source:
         specifier: ~5.5.0
-        version: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+        version: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -111,7 +111,7 @@ importers:
         version: 0.2.7
       reactiveweb:
         specifier: ^1.2.1
-        version: 1.2.2(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
+        version: 1.2.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
       release-plan:
         specifier: ^0.8.0
         version: 0.8.0
@@ -139,9 +139,6 @@ importers:
 
   docs-app:
     dependencies:
-      '@universal-ember/kolay-ui':
-        specifier: workspace:^
-        version: file:ui(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-modifier@4.1.0)(ember-primitives@0.11.3)(ember-repl@3.0.0)(ember-resources@7.0.0)(ember-source@5.6.0)(qunit@2.20.1)(reactiveweb@1.2.2)(tracked-built-ins@3.3.0)
       '@universal-ember/test-support':
         specifier: ^0.0.0
         version: 0.0.0(@babel/core@7.24.0)(@glint/template@1.3.0)(ember-source@5.6.0)(qunit@2.20.1)(webpack@5.90.3)
@@ -159,7 +156,7 @@ importers:
         version: 1.0.3
       kolay:
         specifier: workspace:^
-        version: file:(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(@universal-ember/kolay-ui@0.0.0)(ember-modifier@4.1.0)(ember-primitives@0.11.3)(ember-repl@3.0.0)(ember-resources@7.0.0)(ember-source@5.6.0)(reactiveweb@1.2.2)(tracked-built-ins@3.3.0)(typescript@5.3.3)
+        version: file:(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-modifier@4.1.0)(ember-primitives@0.11.3)(ember-repl@3.0.0)(ember-resources@7.0.0)(ember-source@5.6.0)(qunit@2.20.1)(reactiveweb@1.2.2)(tracked-built-ins@3.3.0)(typescript@5.3.3)
       reactiveweb:
         specifier: ^1.2.1
         version: 1.2.2(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)
@@ -339,8 +336,6 @@ importers:
         specifier: ^5.90.3
         version: 5.90.3
     dependenciesMeta:
-      '@universal-ember/kolay-ui':
-        injected: true
       kolay:
         injected: true
 
@@ -412,7 +407,7 @@ importers:
         version: 3.0.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-resources@7.0.0)(ember-source@5.5.0)(reactiveweb@1.2.2)
       ember-source:
         specifier: ~5.5.0
-        version: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+        version: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
       ember-template-lint:
         specifier: ^5.13.0
         version: 5.13.0
@@ -2317,6 +2312,7 @@ packages:
       semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@embroider/babel-loader-9@3.1.1(@embroider/core@3.4.5)(supports-color@8.1.1)(webpack@5.90.3):
     resolution: {integrity: sha512-8mIDRXvwntYIQc2JFVvGXEppHUJRhw+6aEzHtbCZDr4oOKw55IyY+RHzas3JILRq64owLA+Ox0yu6nkwL1ApRQ==}
@@ -2647,10 +2643,9 @@ packages:
       '@glint/template': 1.3.0
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@embroider/webpack@3.2.2(@embroider/core@3.4.5)(webpack@5.90.3):
     resolution: {integrity: sha512-ygUQiej6uEgtF63opuyzvnoF8SjEsgOFaIDY9osaMKmoFe06QidjT2utLVqOB+k3vBiYfxQkVZ1HJaM0ud4F4A==}
@@ -2962,7 +2957,6 @@ packages:
       '@glimmer/util': 0.84.3
       '@glimmer/wire-format': 0.84.3
       '@simple-dom/interface': 1.4.0
-    dev: true
 
   /@glimmer/compiler@0.85.13:
     resolution: {integrity: sha512-To8a+yScHAHE9/PpwuHyz2yYTBM2+m1Z6l4B9A6LgjkKeu0K7plv2c03V9JpsA3mMJBROJ1mfxOUuQsvTidEkg==}
@@ -3010,7 +3004,6 @@ packages:
       '@glimmer/global-context': 0.84.3
       '@glimmer/interfaces': 0.84.3
       '@glimmer/util': 0.84.3
-    dev: true
 
   /@glimmer/destroyable@0.85.13:
     resolution: {integrity: sha512-fE3bhjDAzYsYQ+rm1qlu+6kP8f0CClHYynp1CWhskDc+qM0Jt7Up08htZK8/Ttaw7RXgi43Fe7FrQtOMUlrVlg==}
@@ -3029,7 +3022,6 @@ packages:
       '@glimmer/env': 0.1.7
       '@glimmer/interfaces': 0.84.3
       '@glimmer/vm': 0.84.3
-    dev: true
 
   /@glimmer/encoder@0.85.13:
     resolution: {integrity: sha512-GukVAeHxDAucbiExjl8lV8BYQXTkV2Co8IXnX5vKaomcZ+fwudGmvzbo2myq+WZ1llqnkZ45DVcqa9BVh9eNWg==}
@@ -3044,7 +3036,6 @@ packages:
     resolution: {integrity: sha512-8Oy9Wg5IZxMEeAnVmzD2NkObf89BeHoFSzJgJROE/deutd3rxg83mvlOez4zBBGYwnTb+VGU2LYRpet92egJjA==}
     dependencies:
       '@glimmer/env': 0.1.7
-    dev: true
 
   /@glimmer/global-context@0.85.13:
     resolution: {integrity: sha512-JY/TQ+9dyukQVuTwKlF3jVXaWUwxx676KtclYf6SphtJQu2/mysxqj9XIAowOahhi9m7E7hzHkxAl9bm2FXXjQ==}
@@ -3067,7 +3058,6 @@ packages:
 
   /@glimmer/low-level@0.78.2:
     resolution: {integrity: sha512-0S6TWOOd0fzLLysw1pWZN0TgasaHmYs1Sjz9Til1mTByIXU1S+1rhdyr2veSQPO/aRjPuEQyKXZQHvx23Zax6w==}
-    dev: true
 
   /@glimmer/manager@0.84.3:
     resolution: {integrity: sha512-FtcwvrQ3HWlGRGChwlXiisMeKf9+XcCkMwVrrO0cxQavT01tIHx40OFtPOhXKGbgXGtRKcJI8XR41aK9t2kvyg==}
@@ -3079,7 +3069,6 @@ packages:
       '@glimmer/reference': 0.84.3
       '@glimmer/util': 0.84.3
       '@glimmer/validator': 0.84.3
-    dev: true
 
   /@glimmer/manager@0.85.13:
     resolution: {integrity: sha512-HwJoD9qAVPQ6hHNMUFTvQtJi5NIO1JzOT0kauyln754G6ggT07IFmi+b1R4WeJJJndZpuR3Ad4PS4usRnI89Zw==}
@@ -3102,7 +3091,6 @@ packages:
       '@glimmer/util': 0.84.3
       '@simple-dom/document': 1.4.0
       '@simple-dom/interface': 1.4.0
-    dev: true
 
   /@glimmer/node@0.85.13:
     resolution: {integrity: sha512-Lb/0zPoucm8hQ/qd6A8RYgdoLSC5tulZJ7LahAq1/bpG42vJyQMGYBjxVL2ffQv+Yxao/nEQxUP5ssoLXS+gvw==}
@@ -3122,7 +3110,6 @@ packages:
       '@glimmer/util': 0.84.3
       '@glimmer/vm': 0.84.3
       '@glimmer/wire-format': 0.84.3
-    dev: true
 
   /@glimmer/opcode-compiler@0.85.13:
     resolution: {integrity: sha512-EySW/IsMoO+lWW2TC31zsHqanST/5lTGoZOrB9zy7FmiUaPGD0RxeOEBU8rTRHzYxNzoJAsX7l3Hv6Y0y2ABZg==}
@@ -3142,7 +3129,6 @@ packages:
     resolution: {integrity: sha512-ZwA0rU4V8m0z4ncXtWD2QEU6eh61wkKKQUThahPYhfB+JYceVM6Grx7uWeiAxc2v3ncpvbYqIGdnICXDMloxAA==}
     dependencies:
       '@glimmer/util': 0.84.3
-    dev: true
 
   /@glimmer/owner@0.85.13:
     resolution: {integrity: sha512-4FhMR9qHuKu7sZIIsulqBvzP9UWYFtjxzF+eQ5cxmr+0uxjJN8/rZbRG8vPbJs3OoV2k+vHj4BYhLyflSjRaZw==}
@@ -3158,7 +3144,6 @@ packages:
       '@glimmer/manager': 0.84.3
       '@glimmer/opcode-compiler': 0.84.3
       '@glimmer/util': 0.84.3
-    dev: true
 
   /@glimmer/program@0.85.13:
     resolution: {integrity: sha512-E+89jmD+52fB2/HqeOW2vim1x8wNTkpfPpzsGeVFlyZHxBaMR95zw1+rgl2aE1pyRoZR3csL4qSBaJb26Sp6Pw==}
@@ -3180,7 +3165,6 @@ packages:
       '@glimmer/interfaces': 0.84.3
       '@glimmer/util': 0.84.3
       '@glimmer/validator': 0.84.3
-    dev: true
 
   /@glimmer/reference@0.85.13:
     resolution: {integrity: sha512-rkMlY6RUkwZwfO7fQodKQw5WOLCKNZPkVAloaVJSqpyKjHRNjMaD3TZhfNmlGIVdNgVRRsOWSWdTL5CUUzDlwQ==}
@@ -3207,7 +3191,6 @@ packages:
       '@glimmer/vm': 0.84.3
       '@glimmer/wire-format': 0.84.3
       '@simple-dom/interface': 1.4.0
-    dev: true
 
   /@glimmer/runtime@0.85.13:
     resolution: {integrity: sha512-jum5u2mX0WOAAF3L0pVZ/AOAMjJRKfGIqcStUYldmnf/xCFucKsh2WzSBS5KxlHDt4OGs00GflkpoTZkqPnCmg==}
@@ -3289,7 +3272,6 @@ packages:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.84.3
-    dev: true
 
   /@glimmer/validator@0.85.13:
     resolution: {integrity: sha512-vWSHpYq1gbnssxwyW0t7JrSbfZj8jZUAUdqp9bymHZOgru7QZn0mYCuJbfYDvF9pzsTQ+i0zZBMxZRHeAWbasQ==}
@@ -3305,7 +3287,6 @@ packages:
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.0)
     transitivePeerDependencies:
       - '@babel/core'
-    dev: true
 
   /@glimmer/vm-babel-plugins@0.85.13(@babel/core@7.24.0):
     resolution: {integrity: sha512-B5R+t7o0Dlfz7GYu6liQ/GERAq/Fb775KZJeEaIwX2odJDKyIfOU+m/bLHpoVevY4V/x+qB8tVCA4Nv5LXu3Kg==}
@@ -3320,7 +3301,6 @@ packages:
     dependencies:
       '@glimmer/interfaces': 0.84.3
       '@glimmer/util': 0.84.3
-    dev: true
 
   /@glimmer/vm@0.85.13:
     resolution: {integrity: sha512-x/FwTAFnoIzu/TzJYuqWI1rWoIJUthKZ6n37q5Nr8TVoFqOVXk7q9k53etcAhxLEwBjX/cox6i1FxCuv5vpc8Q==}
@@ -3333,7 +3313,6 @@ packages:
     dependencies:
       '@glimmer/interfaces': 0.84.3
       '@glimmer/util': 0.84.3
-    dev: true
 
   /@glimmer/wire-format@0.85.13:
     resolution: {integrity: sha512-q6bHPfjSYE9jH27L75lUzyhSpBA+iONzsJVXewdwO4GdYYCC4s+pfUaJg7ZYNFDcHDuVKUcLhBb/NICDzMA5Uw==}
@@ -8150,10 +8129,9 @@ packages:
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.8.7
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ember-async-data@1.0.3(ember-source@5.6.0):
     resolution: {integrity: sha512-54OtoQwNi+/ZvPOVuT4t8fcHR9xL8N7kBydzcZSo6BIEsLYeXPi3+jUR8niWjfjXXhKlJ8EWXR0lTeHleTrxbw==}
@@ -8233,7 +8211,7 @@ packages:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.0)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -8253,6 +8231,24 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
       ember-source: 5.6.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  /ember-cached-decorator-polyfill@1.0.2(@glint/template@1.3.0)(ember-source@5.5.0):
+    resolution: {integrity: sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==}
+    engines: {node: 14.* || >= 16}
+    peerDependencies:
+      ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
+    dependencies:
+      '@embroider/macros': 1.14.0(@glint/template@1.3.0)
+      '@glimmer/tracking': 1.1.2
+      babel-import-util: 1.4.1
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -8750,12 +8746,11 @@ packages:
     dependencies:
       '@embroider/addon-shim': 1.8.3
       '@embroider/util': 1.12.1(@glint/template@1.3.0)(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - '@glint/environment-ember-loose'
       - '@glint/template'
       - supports-color
-    dev: true
 
   /ember-eslint-parser@0.3.8(@babel/core@7.24.0)(@typescript-eslint/parser@7.1.0)(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-P1VEHlbL8RZ/2GcdwaiG/jySWJzY6eBPkzQoA3g4lSDSG6CH0Xwmlem38wIdYy/lN28EBu++vlJvRm2KROpDRw==}
@@ -8790,10 +8785,9 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-cli-version-checker: 5.1.2
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ember-functions-as-helper-polyfill@2.1.2(ember-source@5.6.0):
     resolution: {integrity: sha512-yvW6xykvZEIYzzwlrC/g9yu6LtLkkj5F+ho6U+BDxN1uREMgoMOZnji7sSILn5ITVpaJ055DPcO+utEFD7IZOA==}
@@ -8830,10 +8824,9 @@ packages:
       '@embroider/addon-shim': 1.8.7
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ember-modifier@4.1.0(ember-source@5.6.0):
     resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}
@@ -8931,15 +8924,14 @@ packages:
       ember-element-helper: 0.8.5(@glint/template@1.3.0)(ember-source@5.5.0)
       ember-modifier: 4.1.0(ember-source@5.5.0)
       ember-resources: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
       ember-velcro: 2.1.3(ember-modifier@4.1.0)(ember-source@5.5.0)
-      reactiveweb: 1.2.2(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
+      reactiveweb: 1.2.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
       tracked-toolbox: 2.0.0(ember-source@5.5.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/environment-ember-loose'
       - supports-color
-    dev: true
 
   /ember-qunit@8.0.2(@ember/test-helpers@3.3.0)(@glint/template@1.3.0)(ember-source@5.6.0)(qunit@2.20.1):
     resolution: {integrity: sha512-Rf60jeUTWNsF3Imf/FLujW/B/DFmKVXKmXO1lirTXjpertKfwRhp/3MnN8a/U/WyodTIsERkInGT1IqTtphCdQ==}
@@ -8985,7 +8977,7 @@ packages:
       content-tag: 1.2.2
       decorator-transforms: 1.1.0(@babel/core@7.24.0)
       ember-resources: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
       line-column: 1.0.2
       magic-string: 0.30.8
       mdast: 3.0.0
@@ -9077,12 +9069,12 @@ packages:
       content-tag: 1.2.2
       decorator-transforms: 1.1.0(@babel/core@7.24.0)
       ember-resources: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
       line-column: 1.0.2
       magic-string: 0.30.8
       mdast: 3.0.0
       parse-static-imports: 1.1.0
-      reactiveweb: 1.2.2(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
+      reactiveweb: 1.2.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
       rehype-raw: 6.1.1
       rehype-stringify: 9.0.4
       remark-gfm: 3.0.1
@@ -9095,7 +9087,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    dev: true
 
   /ember-resolver@11.0.1(ember-source@5.6.0):
     resolution: {integrity: sha512-ucBk3oM+PR+AfYoSUXeQh8cDQS1sSiEKp4Pcgbew5cFMSqPxJfqd1zyZsfQKNTuyubeGmWxBOyMVSTvX2LeCyg==}
@@ -9128,10 +9119,9 @@ packages:
       '@glimmer/component': 1.1.2(@babel/core@7.24.0)
       '@glimmer/tracking': 1.1.2
       '@glint/template': 1.3.0
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ember-resources@7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0):
     resolution: {integrity: sha512-BRah6wsXMejHWfTBFJZ+8MYeUz4ylLP4afUxK+sPCb+Nv3LKqBTEPpvahHoE5FwY56pOPhg1TQWJI/+Aj1rWWA==}
@@ -9174,11 +9164,9 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ember-source@5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3):
+  /ember-source@5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3):
     resolution: {integrity: sha512-OTJ9kt76wyvEkdSdjmonoLUTTqYg5OaFxicSiwKsjX9gJ9bVzuCu3uInhBKEfTdC5lSBMEcVuGk8f9LUF3pxJQ==}
     engines: {node: '>= 16.*'}
-    peerDependencies:
-      '@glimmer/component': ^1.1.2
     dependencies:
       '@babel/helper-module-imports': 7.22.15
       '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.24.0)
@@ -9232,7 +9220,6 @@ packages:
       - rsvp
       - supports-color
       - webpack
-    dev: true
 
   /ember-source@5.6.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3):
     resolution: {integrity: sha512-dtxi3cVPT4/+NyhA+a+4UL/i+ut4Fuu3uJAgkVqrN1XlK4TXpyVp9I6VbH7DjD5+LJdF1+UqIn8GJ50dIdoH2Q==}
@@ -9400,10 +9387,9 @@ packages:
       '@floating-ui/dom': 1.6.3
       ember-functions-as-helper-polyfill: 2.1.2(ember-source@5.5.0)
       ember-modifier: 4.1.0(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ember-velcro@2.1.3(ember-modifier@4.1.0)(ember-source@5.6.0):
     resolution: {integrity: sha512-4V6rT9b9XSeMaPmiYYA2hIhfMD088vru6AvfGWBY7L1w/st5hYv6iIfamy9+W1l9xKvIH3Hcl8+B0637/SRmzQ==}
@@ -11411,6 +11397,7 @@ packages:
   /highlight.js@11.9.0:
     resolution: {integrity: sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==}
     engines: {node: '>=12.0.0'}
+    dev: false
 
   /highlightjs-glimmer@2.2.1(highlight.js@11.9.0):
     resolution: {integrity: sha512-5vQiop/MgoLSqms7PAwCYAWRxDHnwD24nWFV03k8deH14XbsAb7C27O/UQCk8/ofPp18nBc1LR4yTNIg1cIgPQ==}
@@ -11419,6 +11406,7 @@ packages:
       highlight.js: '>= 11.0.0'
     dependencies:
       highlight.js: 11.9.0
+    dev: false
 
   /homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -14697,7 +14685,7 @@ packages:
       ember-async-data: 1.0.3(ember-source@5.5.0)
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.0)(@glint/template@1.3.0)(ember-source@5.5.0)
       ember-resources: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/component'
@@ -14720,6 +14708,27 @@ packages:
       ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.0)(@glint/template@1.3.0)(ember-source@5.6.0)
       ember-resources: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)
       ember-source: 5.6.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glimmer/component'
+      - '@glimmer/tracking'
+      - '@glint/template'
+      - supports-color
+
+  /reactiveweb@1.2.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0):
+    resolution: {integrity: sha512-eYSYMfPPlEiRI/emc8g61TSqxKlchWQzvUWURZvj7LV0LjdyZT2DD0UjC1NUBflvj9zFK7A8V/rjv6ec/ZUOLw==}
+    peerDependencies:
+      '@ember/test-waiters': ^3.1.0
+      ember-source: '>= 3.28.0'
+    dependencies:
+      '@ember/test-waiters': 3.1.0
+      '@embroider/addon-shim': 1.8.7
+      '@embroider/macros': 1.14.0(@glint/template@1.3.0)
+      decorator-transforms: 1.1.0(@babel/core@7.24.0)
+      ember-async-data: 1.0.3(ember-source@5.5.0)
+      ember-cached-decorator-polyfill: 1.0.2(@glint/template@1.3.0)(ember-source@5.5.0)
+      ember-resources: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/component'
@@ -16646,11 +16655,10 @@ packages:
     dependencies:
       '@embroider/addon-shim': 1.8.7
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    dev: true
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -17835,7 +17843,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  file:(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(@universal-ember/kolay-ui@0.0.0)(ember-modifier@4.1.0)(ember-primitives@0.11.3)(ember-repl@3.0.0)(ember-resources@7.0.0)(ember-source@5.6.0)(reactiveweb@1.2.2)(tracked-built-ins@3.3.0)(typescript@5.3.3):
+  file:(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-modifier@4.1.0)(ember-primitives@0.11.3)(ember-repl@3.0.0)(ember-resources@7.0.0)(ember-source@5.6.0)(qunit@2.20.1)(reactiveweb@1.2.2)(tracked-built-ins@3.3.0)(typescript@5.3.3):
     resolution: {directory: '', type: directory}
     id: 'file:'
     name: kolay
@@ -17845,7 +17853,6 @@ packages:
       '@glimmer/component': ^1.1.2
       '@glimmer/tracking': ^1.1.2
       '@glint/template': ^1.3.0
-      '@universal-ember/kolay-ui': workspace:^
       ember-modifier: ^4.1.0
       ember-primitives: ^0.11.3
       ember-repl: ^3.0.0
@@ -17875,6 +17882,9 @@ packages:
       typedoc: 0.25.10(typescript@5.3.3)
       unplugin: 1.8.0
     transitivePeerDependencies:
+      - '@babel/core'
+      - qunit
+      - supports-color
       - typescript
     dev: false
 
@@ -17945,12 +17955,12 @@ packages:
       ember-primitives: 0.11.3(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-modifier@4.1.0)(ember-resources@7.0.0)(ember-source@5.5.0)
       ember-repl: 3.0.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-resources@7.0.0)(ember-source@5.5.0)(reactiveweb@1.2.2)
       ember-resources: 7.0.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.24.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(webpack@5.90.3)
+      ember-source: 5.5.0(@babel/core@7.24.0)(@glint/template@1.3.0)(webpack@5.90.3)
       highlight.js: 11.9.0
       highlightjs-glimmer: 2.2.1(highlight.js@11.9.0)
-      reactiveweb: 1.2.2(@babel/core@7.24.0)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
+      reactiveweb: 1.2.2(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.5.0)
       tracked-built-ins: 3.3.0
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    dev: true
+    dev: false


### PR DESCRIPTION
So far, no.
If we could have type=module for auto-import and embroider builds, then this would be a non issue, and there would be only one package instead of two.