### PR TITLE
Utilize routes to better manage error redirection and page loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
       ]
     },
     "overrides": {
+      "@embroider/macros": "1.16.5",
       "@ember/test-waiters": "^3.1.0",
       "webpack": "^5.90.3",
       "ember-repl": "^4.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@embroider/macros': 1.16.5
   '@ember/test-waiters': ^3.1.0
   webpack: ^5.90.3
   ember-repl: ^4.1.1
@@ -1304,24 +1305,6 @@ packages:
       '@embroider/core': ^3.4.0
       webpack: ^5.90.3
 
-  '@embroider/macros@1.16.1':
-    resolution: {integrity: sha512-yBavtQBbiCjIW4tTNdoS+5/eu3mckZImrcVFkloRvZ5ZWvs2zqnLJVtfNsPMxhWu6dknFlmLqfuT30+kqnsQbg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    peerDependencies:
-      '@glint/template': ^1.0.0
-    peerDependenciesMeta:
-      '@glint/template':
-        optional: true
-
-  '@embroider/macros@1.16.3':
-    resolution: {integrity: sha512-WOQjl3aT3I5gG4XDLpCJjrKhNSapgH7FiLtpzM6lGfTFoA90rZojfjf5MELwzqlhjug0U2xLvyjw0l+kiBmDig==}
-    engines: {node: 12.* || 14.* || >= 16}
-    peerDependencies:
-      '@glint/template': ^1.0.0
-    peerDependenciesMeta:
-      '@glint/template':
-        optional: true
-
   '@embroider/macros@1.16.5':
     resolution: {integrity: sha512-Oz8bUZvZzOV1Gk3qSgIzZJJzs6acclSTcEFyB+KdKbKqjTC3uebn53aU2gAlLU7/YdTRZrg2gNbQuwAp+tGkGg==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -1330,14 +1313,6 @@ packages:
     peerDependenciesMeta:
       '@glint/template':
         optional: true
-
-  '@embroider/shared-internals@2.6.0':
-    resolution: {integrity: sha512-A2BYQkhotdKOXuTaxvo9dqOIMbk+2LqFyqvfaaePkZcFJvtCkvTaD31/sSzqvRF6rdeBHjdMwU9Z2baPZ55fEQ==}
-    engines: {node: 12.* || 14.* || >= 16}
-
-  '@embroider/shared-internals@2.6.1':
-    resolution: {integrity: sha512-STU1oDP36JQY+zpivyAfXGXadN664d+DOiVNBUW+4AAuWLVxIRWDIuFj8UxzREXZU9trZY8vOhKwKQtfEgdwSg==}
-    engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/shared-internals@2.6.2':
     resolution: {integrity: sha512-jL3Bjn8C73AUBlTex+VixP7YmqvPNN/BZFB85odTstzLFOuR8y2mmGiuWbq17qNuFyoxc6xtndMnAeqwCXBNkA==}
@@ -10633,36 +10608,6 @@ snapshots:
       '@embroider/core': 3.4.14(@glint/template@1.4.0)
       webpack: 5.92.1
 
-  '@embroider/macros@1.16.1(@glint/template@1.4.0)':
-    dependencies:
-      '@embroider/shared-internals': 2.6.0
-      assert-never: 1.2.1
-      babel-import-util: 2.1.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.8
-      semver: 7.6.2
-    optionalDependencies:
-      '@glint/template': 1.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@embroider/macros@1.16.3(@glint/template@1.4.0)':
-    dependencies:
-      '@embroider/shared-internals': 2.6.1
-      assert-never: 1.2.1
-      babel-import-util: 2.1.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.8
-      semver: 7.6.2
-    optionalDependencies:
-      '@glint/template': 1.4.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@embroider/macros@1.16.5(@glint/template@1.4.0)':
     dependencies:
       '@embroider/shared-internals': 2.6.2
@@ -10675,36 +10620,6 @@ snapshots:
       semver: 7.6.2
     optionalDependencies:
       '@glint/template': 1.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@embroider/shared-internals@2.6.0':
-    dependencies:
-      babel-import-util: 2.1.1
-      debug: 4.3.5(supports-color@9.4.0)
-      ember-rfc176-data: 0.3.18
-      fs-extra: 9.1.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      minimatch: 3.1.2
-      resolve-package-path: 4.0.3
-      semver: 7.6.2
-      typescript-memoize: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@embroider/shared-internals@2.6.1':
-    dependencies:
-      babel-import-util: 2.1.1
-      debug: 4.3.5(supports-color@9.4.0)
-      ember-rfc176-data: 0.3.18
-      fs-extra: 9.1.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      minimatch: 3.1.2
-      resolve-package-path: 4.0.3
-      semver: 7.6.2
-      typescript-memoize: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10740,7 +10655,7 @@ snapshots:
 
   '@embroider/util@1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.92.1))':
     dependencies:
-      '@embroider/macros': 1.16.1(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-source: 5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.92.1)
@@ -14363,7 +14278,7 @@ snapshots:
       '@babel/runtime': 7.24.7
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.1(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@floating-ui/dom': 1.6.6
       '@glimmer/component': 1.1.2(@babel/core@7.24.7)
       '@glimmer/tracking': 1.1.2
@@ -14403,7 +14318,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/standalone': 7.24.7
       '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.3(@glint/template@1.4.0)
+      '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       babel-import-util: 3.0.0
       babel-plugin-ember-template-compilation: 2.2.5
       broccoli-file-creator: 2.1.1

--- a/ui/package.json
+++ b/ui/package.json
@@ -99,6 +99,7 @@
       "./components/logs.js": "./dist/_app_/components/logs.js",
       "./components/page-nav.js": "./dist/_app_/components/page-nav.js",
       "./components/page.js": "./dist/_app_/components/page.js",
+      "./routes/page.js": "./dist/_app_/routes/page.js",
       "./services/kolay/api-docs.js": "./dist/_app_/services/kolay/api-docs.js",
       "./services/kolay/compiler.js": "./dist/_app_/services/kolay/compiler.js",
       "./services/kolay/compiler/compile-state.js": "./dist/_app_/services/kolay/compiler/compile-state.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -106,6 +106,7 @@
       "./services/kolay/compiler/import-map.js": "./dist/_app_/services/kolay/compiler/import-map.js",
       "./services/kolay/compiler/reactive.js": "./dist/_app_/services/kolay/compiler/reactive.js",
       "./services/kolay/docs.js": "./dist/_app_/services/kolay/docs.js",
+      "./services/kolay/reasons.js": "./dist/_app_/services/kolay/reasons.js",
       "./services/kolay/selected.js": "./dist/_app_/services/kolay/selected.js",
       "./services/kolay/types.js": "./dist/_app_/services/kolay/types.js"
     }

--- a/ui/rollup.config.mjs
+++ b/ui/rollup.config.mjs
@@ -35,6 +35,7 @@ export default {
       'helpers/**/*.js',
       'modifiers/**/*.js',
       'services/**/*.js',
+      'routes/**/*.js',
     ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from

--- a/ui/src/routes/page.ts
+++ b/ui/src/routes/page.ts
@@ -1,0 +1,56 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+import type Docs from '../services/kolay/docs.ts';
+import type RouterService from '@ember/routing/router-service';
+import type Transition from '@ember/routing/transition';
+
+interface WithIntent {
+  intent: {
+    url: string;
+  }
+}
+
+/**
+ * This route is provided by Kolay.
+ * It is responsible for stopping folks from navigating to
+ * pages that don't exist.
+ *
+ * NOTE that all routes under the this route *must* exist in the manifest.
+ */
+export default class KolayPageRoute extends Route {
+  @service('kolay/docs') declare docs: Docs;
+  @service declare router: RouterService;
+
+    /**
+     * Does the page exist?
+     * - no: redirect to 'application'
+     * - yes: do nothing
+     */
+  beforeModel(transition: Transition) {
+    /**
+     * NOTE: intent is private, but people use it, as there is
+     *       interest in making it public (though the routing
+     *       layer is about to be rewritten entirely)
+     */
+    let { intent } = transition as unknown as WithIntent;
+    let attempttedURL = intent.url;
+
+    let page = this.docs.pages.find(page => page.path === attempttedURL);
+
+    if (!page) {
+      /**
+       * TODO: make this configurable via the "setup" hook
+       *       in the user's application route.
+       */
+      return this.router.replaceWith('application');
+    }
+  }
+
+  /**
+  * Load the page for the compiler
+  */
+  model(path, transition) {
+    console.log({ path, transition });
+  }
+}

--- a/ui/src/routes/page.ts
+++ b/ui/src/routes/page.ts
@@ -49,8 +49,18 @@ export default class KolayPageRoute extends Route {
 
   /**
   * Load the page for the compiler
+  *
+  * This relies on the browser's built in cache.
+  * If the page is already fetched, we don't hit the network again when we try to render it (even if we use fetch to ask for the page)
   */
-  model(path, transition) {
-    console.log({ path, transition });
+  async model({ page }: { page: string }) {
+    /**
+      * page should have .md at the end already
+      */
+    await fetch(`/docs/${page}.broken`)
+  }
+
+  error = (...args) => {
+    console.log(...args);
   }
 }

--- a/ui/src/routes/page.ts
+++ b/ui/src/routes/page.ts
@@ -1,15 +1,10 @@
+import { assert } from '@ember/debug';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 import type Docs from '../services/kolay/docs.ts';
+import type Selected from '../services/kolay/selected.ts';
 import type RouterService from '@ember/routing/router-service';
-import type Transition from '@ember/routing/transition';
-
-interface WithIntent {
-  intent: {
-    url: string;
-  }
-}
 
 /**
  * This route is provided by Kolay.
@@ -17,50 +12,72 @@ interface WithIntent {
  * pages that don't exist.
  *
  * NOTE that all routes under the this route *must* exist in the manifest.
+ *
+ * This whole Route is hacks on what would otherwise be derived data.
+ * *however* -- Ember is not set up to route ergonomically with derived data patterns.
  */
 export default class KolayPageRoute extends Route {
   @service('kolay/docs') declare docs: Docs;
+  @service('kolay/selected') declare selected: Selected;
   @service declare router: RouterService;
 
-    /**
-     * Does the page exist?
-     * - no: redirect to 'application'
-     * - yes: do nothing
-     */
-  beforeModel(transition: Transition) {
-    /**
-     * NOTE: intent is private, but people use it, as there is
-     *       interest in making it public (though the routing
-     *       layer is about to be rewritten entirely)
-     */
-    let { intent } = transition as unknown as WithIntent;
-    let attempttedURL = intent.url;
-
-    let page = this.docs.pages.find(page => page.path === attempttedURL);
-
-    if (!page) {
-      /**
-       * TODO: make this configurable via the "setup" hook
-       *       in the user's application route.
-       */
-      return this.router.replaceWith('application');
-    }
-  }
-
   /**
-  * Load the page for the compiler
-  *
-  * This relies on the browser's built in cache.
-  * If the page is already fetched, we don't hit the network again when we try to render it (even if we use fetch to ask for the page)
-  */
+   * Load the page for the compiler (if it exists)
+   *
+   * This relies on the browser's built in cache.
+   * If the page is already fetched, we don't hit the network again when we try to render it (even if we use fetch to ask for the page)
+   */
   async model({ page }: { page: string }) {
+    /* does not contain leading slash, but does have .md */
+    let visitedPath = page;
     /**
-      * page should have .md at the end already
-      */
-    await fetch(`/docs/${page}.broken`)
-  }
+     * page should have .md at the end already
+     */
+    let mdFilePath = `/docs/${visitedPath}`;
 
-  error = (...args) => {
-    console.log(...args);
+    let attemptedGroupName = this.docs.groupForPath(`/${visitedPath}`);
+    let attemptedGroup = this.docs.groupFor(attemptedGroupName);
+    let attemptedGroupPages = attemptedGroup?.list ?? [];
+    // This removes query params (and also the md, which we need to add back)
+    // NOTE: that we may be able to simplify a few things by not chopping off the .md
+    //       extension
+    let cleanedPath = this.selected.pathFromUrl(visitedPath);
+    let foundPage = attemptedGroupPages.find(
+      (page) => page.path === `/${cleanedPath}.md`,
+    )?.path;
+
+    if (!foundPage) {
+      if (attemptedGroupName === cleanedPath) {
+        foundPage = attemptedGroupPages[0]?.path;
+        this.router.replaceWith(foundPage);
+
+        return;
+      }
+    }
+
+    /**
+     * Were we trying to just get to the new group?
+     */
+    if (!foundPage) {
+      assert(
+        `on.pageNotFound must be a function. Did you pass the correct value in your 'setup' call?`,
+        typeof this.docs._eventHandlers.pageNotFound === 'function',
+      );
+      this.docs._eventHandlers.pageNotFound(page, 'not in manifest');
+
+      return;
+    }
+
+    let response = await fetch(mdFilePath);
+
+    if (response.status >= 400) {
+      assert(
+        `on.pageNotFound must be a function. Did you pass the correct value in your 'setup' call?`,
+        typeof this.docs._eventHandlers.pageNotFound === 'function',
+      );
+      this.docs._eventHandlers.pageNotFound(mdFilePath, '404 during fetch');
+
+      return;
+    }
   }
 }

--- a/ui/src/services/kolay/docs.ts
+++ b/ui/src/services/kolay/docs.ts
@@ -30,7 +30,7 @@ export default class DocsService extends Service {
   @tracked rehypePlugins?: UnifiedPlugin[];
   _docs: Manifest | undefined;
   _eventHandlers = {
-    pageNotFound: () => {
+    pageNotFound: (_attemptedPagePath: string, _reason: NotFoundReason) => {
       this.router.replaceWith('application');
     },
   };

--- a/ui/src/services/kolay/reasons.ts
+++ b/ui/src/services/kolay/reasons.ts
@@ -1,0 +1,1 @@
+export type NotFoundReason = 'not in manifest' | '404 during fetch';

--- a/ui/src/services/kolay/selected.ts
+++ b/ui/src/services/kolay/selected.ts
@@ -73,21 +73,25 @@ export default class Selected extends Service {
   }
 
   get path(): string | undefined {
-    if (!this.router.currentURL) return firstPath;
-
-    let [path] = this.router.currentURL.split('?');
-    let result = path && path !== '/' ? path : firstPath;
-
-    return result?.replace(/\.md$/, '');
+    return this.pathFromUrl(this.router.currentURL);
   }
 
   get page(): Page | undefined {
     if (!this.path) return;
 
-    return this.#findByPath(this.path);
+    return this.findByPath(this.path);
   }
 
-  #findByPath = (path: string) => {
+  pathFromUrl = (url: string | null) => {
+    if (!url) return firstPath;
+
+    let [path] = url.split('?');
+    let result = path && path !== '/' ? path : firstPath;
+
+    return result?.replace(/\.md$/, '');
+  };
+
+  findByPath = (path: string) => {
     return this.docs.pages.find((page) => page.path === `${path}.md`);
   };
 }


### PR DESCRIPTION
Compilation is pretty fast once we have the page.

Note that the description here: https://github.com/emberjs/ember.js/pull/20712 may be a better-written counter-argument for using routes (as they exist in today's ember, anyway)