### PR TITLE
Consider 4xx and 5xx status as error instead of trying to render MD

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,7 +28,7 @@ module.exports = {
       },
     },
     {
-      files: ['src/browser/**/*', '**/*.test.ts'],
+      files: ['src/browser/**/*', '**/*.test.ts', 'src/plugins/markdown-pages/types.ts'],
       rules: {
         'n/no-unpublished-import': 'off',
         'n/no-missing-import': 'off',

--- a/docs-app/app/templates/page.gjs
+++ b/docs-app/app/templates/page.gjs
@@ -14,6 +14,7 @@ export default Route(
         <div style="border: 1px solid red; padding: 1rem;">
           {{error}}
         </div>
+        {{(removeLoader)}}
       </:error>
 
       <:success as |Prose|>

--- a/docs-app/app/templates/page.gjs
+++ b/docs-app/app/templates/page.gjs
@@ -11,7 +11,7 @@ export default Route(
   <template>
     <Page>
       <:error as |error|>
-        <div style="border: 1px solid red; padding: 1rem;">
+        <div style="border: 1px solid red; padding: 1rem;" data-page-error>
           {{error}}
         </div>
         {{(removeLoader)}}

--- a/docs-app/public/docs/plugins/kolay.md
+++ b/docs-app/public/docs/plugins/kolay.md
@@ -5,8 +5,8 @@ Kolay requires some build-time static analysis to function.
 `kolay(...)` is the only required plugin. This generates the navigation and information about how Kolay's runtime code will fetch the markdown documents deployed with the app's static assets. Optionally, if a list of packages is provided, apiDocs will be generated from your library's type declarations. Rendering these api docs uses the [Signature Components][ui-signature] or [`APIDocs`][ui-apiDocs] components.
 
 [plugin-kolay]: /plugins/kolay.md
-[ui-signature]: /Runtime/components/component-signature.md
-[ui-apiDocs]: /Runtime/components/api-docs.md
+[ui-signature]: /Runtime/docs/component-signature.md
+[ui-apiDocs]: /Runtime/docs/api-docs.md
 
 Usage in embroider / webpack:
 

--- a/docs-app/public/docs/usage/rendering-pages.md
+++ b/docs-app/public/docs/usage/rendering-pages.md
@@ -21,6 +21,7 @@ export default Route(
         <div style="border: 1px solid red; padding: 1rem;">
           {{error}}
         </div>
+        {{(removeLoader)}}
       </:error>
 
       <:success as |prose|>

--- a/docs-app/tests/docs-app/errors-test.gts
+++ b/docs-app/tests/docs-app/errors-test.gts
@@ -1,4 +1,5 @@
-import { click, visit } from '@ember/test-helpers';
+import { renderSettled } from '@ember/renderer';
+import { click, settled, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 
@@ -31,6 +32,24 @@ module('Errors', function (hooks) {
       await visit(`/Runtime/docs/api-docs.md`);
 
       assert.dom().doesNotContainText(`Page not found for path`);
+    });
+
+    test('the error does not flash between known pages rendering', async function (assert) {
+      visit(`/Runtime/docs/api-docs.md`);
+
+      await renderSettled();
+      assert.dom('[data-page-error]').doesNotExist();
+
+      await settled();
+      assert.dom('[data-page-error]').doesNotExist();
+
+      visit(`/Runtime/util/logs.md`);
+
+      await renderSettled();
+      assert.dom('[data-page-error]').doesNotExist();
+
+      await settled();
+      assert.dom('[data-page-error]').doesNotExist();
     });
   });
 });

--- a/docs-app/tests/docs-app/errors-test.gts
+++ b/docs-app/tests/docs-app/errors-test.gts
@@ -1,0 +1,36 @@
+import { click, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Errors', function (hooks) {
+  setupApplicationTest(hooks);
+
+  module('Not found', function () {
+    test('not in any manifest / group', async function (assert) {
+      await visit('/usage/does-not-exist.md');
+
+      assert.dom().doesNotContainText(`Cannot GET`, 'does not directly expose errors from fetch');
+      assert.dom().doesNotContainText(`null`, 'does not incorrectly render the error');
+
+      assert.dom(`[data-page-error]`).containsText(`Page not found for path`);
+      assert.dom(`[data-page-error]`).containsText(`/usage/does-not-exist`);
+      assert.dom(`[data-page-error]`).containsText(`Using group: root`);
+    });
+
+    test(`can recover after an error`, async function (assert) {
+      await visit('/usage/does-not-exist.md');
+
+      assert.dom(`[data-page-error]`).containsText(`Page not found for path`);
+
+      await click(`a[href="/usage/setup.md"]`);
+
+      assert.dom().doesNotContainText(`Page not found for path`);
+    });
+
+    test(`attempting to visit a route that doesn't exist in the current group, but does exist in another group`, async function (assert) {
+      await visit(`/Runtime/docs/api-docs.md`);
+
+      assert.dom().doesNotContainText(`Page not found for path`);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint:prettier:fix": "prettier . --write",
     "lint:published-types": "attw --pack",
     "start:all": "concurrently 'pnpm --filter ./ui start' 'pnpm --filter ./docs-app start' --names ui,docs",
-    "build": "pnpm prepack",
+    "build": "(cd ui && pnpm build) && pnpm prepack",
     "build:declarations": "tsc --declaration",
     "_syncPnpm": "pnpm sync-dependencies-meta-injected",
     "start:typedoc": "typedoc --options ./typedoc.config.json --watch",

--- a/ui/package.json
+++ b/ui/package.json
@@ -105,6 +105,7 @@
       "./services/kolay/compiler/import-map.js": "./dist/_app_/services/kolay/compiler/import-map.js",
       "./services/kolay/compiler/reactive.js": "./dist/_app_/services/kolay/compiler/reactive.js",
       "./services/kolay/docs.js": "./dist/_app_/services/kolay/docs.js",
+      "./services/kolay/request.js": "./dist/_app_/services/kolay/request.js",
       "./services/kolay/selected.js": "./dist/_app_/services/kolay/selected.js",
       "./services/kolay/types.js": "./dist/_app_/services/kolay/types.js"
     }

--- a/ui/src/components/page.gts
+++ b/ui/src/components/page.gts
@@ -54,9 +54,7 @@ export class Page extends Component<{
   <template>
     {{#if this.selected.hasError}}
       {{yield this.selected.error to='error'}}
-    {{/if}}
-
-    {{#if this.selected.prose}}
+    {{else if this.selected.prose}}
       {{yield this.selected.prose to='success'}}
     {{/if}}
   </template>

--- a/ui/src/components/page.gts
+++ b/ui/src/components/page.gts
@@ -54,7 +54,9 @@ export class Page extends Component<{
   <template>
     {{#if this.selected.hasError}}
       {{yield this.selected.error to='error'}}
-    {{else if this.selected.prose}}
+    {{/if}}
+
+    {{#if this.selected.prose}}
       {{yield this.selected.prose to='success'}}
     {{/if}}
   </template>

--- a/ui/src/services/kolay/docs.ts
+++ b/ui/src/services/kolay/docs.ts
@@ -205,14 +205,14 @@ export default class DocsService extends Service {
     return group;
   };
 
-/**
- * Will return false if a url doesn't exist in any group,
- * or the name of the group that contains the page if the url does exist.
- */
+  /**
+   * Will return false if a url doesn't exist in any group,
+   * or the name of the group that contains the page if the url does exist.
+   */
   groupForURL = (url: string): false | string => {
     for (let groupName of this.availableGroups) {
       let group = this.groupFor(groupName);
-      let page = group.list.find(page => page.path === url);
+      let page = group.list.find((page) => page.path === url);
 
       if (page) {
         return groupName;
@@ -220,7 +220,7 @@ export default class DocsService extends Service {
     }
 
     return false;
-  }
+  };
 }
 
 /**

--- a/ui/src/services/kolay/docs.ts
+++ b/ui/src/services/kolay/docs.ts
@@ -204,6 +204,23 @@ export default class DocsService extends Service {
 
     return group;
   };
+
+/**
+ * Will return false if a url doesn't exist in any group,
+ * or the name of the group that contains the page if the url does exist.
+ */
+  groupForURL = (url: string): false | string => {
+    for (let groupName of this.availableGroups) {
+      let group = this.groupFor(groupName);
+      let page = group.list.find(page => page.path === url);
+
+      if (page) {
+        return groupName;
+      }
+    }
+
+    return false;
+  }
 }
 
 /**

--- a/ui/src/services/kolay/request.ts
+++ b/ui/src/services/kolay/request.ts
@@ -36,7 +36,12 @@ export class MDRequest {
   get hasError() {
     if (!this._doesPageExist) return true;
 
-    return (this.last?.status ?? 600) /* No status??? */ >= 400;
+    /**
+     * Can't have an error if we haven't made a request yet
+     */
+    if (!this.last.status) return false;
+
+    return this.last.status >= 400;
   }
 
   /**

--- a/ui/src/services/kolay/request.ts
+++ b/ui/src/services/kolay/request.ts
@@ -1,0 +1,59 @@
+import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+import { use } from 'ember-resources';
+import { keepLatest } from 'reactiveweb/keep-latest';
+import { RemoteData } from 'reactiveweb/remote-data';
+
+import type DocsService from './docs';
+
+export const OUTPUT_PREFIX = `/docs/`;
+export const OUTPUT_PREFIX_REGEX = /^\/docs\//;
+
+/**
+ * With how data is derived here, the `fetch` request does not execute
+ * if we know ahead of time that the fetch would fail.
+ * e.g.: when the URL is not declared in the manifest.
+ *
+ * The `fetch` only occurs when `last` is accessd.
+ * and `last` is not accessed if `doesPageExist` is ever false.
+ */
+export class MDRequest {
+  constructor(private urlFn: () => string) {}
+
+  @service('kolay/docs') declare docs: DocsService;
+
+  /**
+   * TODO: use a private property when we move to spec-decorators
+   */
+  @use last = RemoteData<string>(this.urlFn);
+
+  @use lastSuccessful = keepLatest({
+    value: () => this.#lastValue,
+    when: () => this.hasError,
+  });
+
+  get hasError() {
+    if (!this._doesPageExist) return true;
+
+    return (this.last?.status ?? 600) /* No status??? */ >= 400;
+  }
+
+  /**
+   * TODO: use a private property when we move to spec-decorators
+   */
+  @cached
+  private get _doesPageExist() {
+    let url = this.urlFn();
+    let pagePath = url.replace(OUTPUT_PREFIX_REGEX, '/');
+    let group = this.docs.groupForURL(pagePath);
+
+    return Boolean(group);
+  }
+
+  get #lastValue() {
+    if (!this._doesPageExist) return '';
+
+    return this.last.value;
+  }
+}

--- a/ui/src/services/kolay/selected.ts
+++ b/ui/src/services/kolay/selected.ts
@@ -47,13 +47,13 @@ class MDRequest {
 }
 
 class Prose {
-  constructor(private docFn: () => ( string | null )) {}
+  constructor(private docFn: () => string | null) {}
 
   @use last = Compiled(this.docFn);
 
   @use lastSuccessful = keepLatest({
     value: () => this.last.component,
-    when: () => !this.last.isReady
+    when: () => !this.last.isReady,
   });
 }
 
@@ -69,8 +69,8 @@ export default class Selected extends Service {
    * be cancelled if it was still pending.
    *******************************************************************/
 
-  @link request = new MDRequest(() => `/docs${this.path}.md`)
-  @link compiled = new Prose(() => this.request.lastSuccessful)
+  @link request = new MDRequest(() => `/docs${this.path}.md`);
+  @link compiled = new Prose(() => this.request.lastSuccessful);
 
   get proseCompiled() {
     return this.compiled.last;
@@ -96,7 +96,7 @@ export default class Selected extends Service {
   }
 
   get hasError() {
-    return Boolean(this.proseCompiled.error) || this.request.hasError ;
+    return Boolean(this.proseCompiled.error) || this.request.hasError;
   }
   get error() {
     return String(this.proseCompiled.error);

--- a/ui/src/services/kolay/selected.ts
+++ b/ui/src/services/kolay/selected.ts
@@ -51,8 +51,8 @@ export default class Selected extends Service {
    ********************************************************************/
 
   @use prose = keepLatest({
-    value: () => this.proseCompiled.component,
-    when: () => !this.proseCompiled.isReady,
+    value: () => this.hasError ? undefined : this.proseCompiled.component,
+    when: () => !this.isReady,
   });
 
   /**
@@ -60,11 +60,11 @@ export default class Selected extends Service {
    * rendering without extra flashes.
    */
   get isReady() {
-    return this.proseCompiled.isReady;
+    return this.proseCompiled.isReady && !this.hasError;
   }
 
   get hasError() {
-    return Boolean(this.proseCompiled.error) || this.proseFile.status?.toString().match(/^[54]/) ;
+    return Boolean(this.proseCompiled.error) || Boolean(this.proseFile.status?.toString().match(/^[54]/)) ;
   }
   get error() {
     return String(this.proseCompiled.error);

--- a/ui/src/services/kolay/selected.ts
+++ b/ui/src/services/kolay/selected.ts
@@ -27,8 +27,8 @@ import type RouterService from '@ember/routing/router-service';
 const firstPath = '/1-get-started/intro.md';
 
 /**
- * Like an ember-concurrency task,
- * if we ignore concurrency and only care about the states
+ * Sort of like an ember-concurrency task...
+ * if we ignore concurrency and only care about the states of the running function
  * (and want automatic invocation based on derivation)
  */
 class MDRequest {

--- a/ui/src/services/kolay/selected.ts
+++ b/ui/src/services/kolay/selected.ts
@@ -29,6 +29,7 @@ const firstPath = '/1-get-started/intro.md';
 /**
  * Like an ember-concurrency task,
  * if we ignore concurrency and only care about the states
+ * (and want automatic invocation based on derivation)
  */
 class MDRequest {
   constructor(private urlFn: () => string) {}

--- a/ui/src/services/kolay/selected.ts
+++ b/ui/src/services/kolay/selected.ts
@@ -38,7 +38,9 @@ export default class Selected extends Service {
    *******************************************************************/
 
   @use proseFile = RemoteData<string>(() => `/docs${this.path}.md`);
-  @use proseCompiled = Compiled(() => this.proseFile.value);
+  @use proseCompiled = Compiled(() => {
+    return this.proseFile.value
+  });
 
   /*********************************************************************
    * This is a pattern to help reduce flashes of content during
@@ -62,7 +64,7 @@ export default class Selected extends Service {
   }
 
   get hasError() {
-    return Boolean(this.proseCompiled.error);
+    return Boolean(this.proseCompiled.error) || this.proseFile.status?.toString().match(/^[54]/) ;
   }
   get error() {
     return String(this.proseCompiled.error);


### PR DESCRIPTION
In the current implementation RemoteData will only error if the underlying JSON parse is unsuccessful on `json` header responses.

There are cases where a static server may serve up 4xx/5xx responses and send invalid MD files that could even be insecure content.

This chance is reduced by the `utilize-routes` changes, but is still possible if a user keeps the docs open and a page is moved/deleted thus causing the server to send invalid MD (in the case of GH pages or S3 static site defaults 404 requests will send the index HTML which likely is not valid to try and parse/render).