### PR TITLE
Fix Hash and other URL oddities: Use URL parsing instead of bespoke regex

### DIFF
--- a/docs-app/tests/docs-app/errors-test.gts
+++ b/docs-app/tests/docs-app/errors-test.gts
@@ -50,6 +50,22 @@ module('Errors', function (hooks) {
 
       await settled();
       assert.dom('[data-page-error]').doesNotExist();
+
+      visit(`/Runtime/docs/api-docs.md#some-hash`);
+
+      await renderSettled();
+      assert.dom('[data-page-error]').doesNotExist();
+
+      await settled();
+      assert.dom('[data-page-error]').doesNotExist();
+
+      visit(`/Runtime/docs/api-docs.md?query-param=value`);
+
+      await renderSettled();
+      assert.dom('[data-page-error]').doesNotExist();
+
+      await settled();
+      assert.dom('[data-page-error]').doesNotExist();
     });
   });
 });

--- a/ui/src/services/kolay/selected.ts
+++ b/ui/src/services/kolay/selected.ts
@@ -96,7 +96,8 @@ export default class Selected extends Service {
   get path(): string | undefined {
     if (!this.router.currentURL) return firstPath;
 
-    let [path] = this.router.currentURL.split('?');
+    let url = new URL(this.router.currentURL, window.location.origin);
+    let path = url.pathname;
     let result = path && path !== '/' ? path : firstPath;
 
     return result?.replace(/\.md$/, '');


### PR DESCRIPTION
The previous work in #84 broke hash urls.

This is because the url parsing had been using a regex. This is now replaced with [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) to better encompass the possible changes to URLs that aren't part of the actual path