### PR TITLE
exclude externals

### DIFF
--- a/src/build/plugins/api-docs/typedoc.js
+++ b/src/build/plugins/api-docs/typedoc.js
@@ -74,7 +74,7 @@ export async function generateTypeDocJSON({ packageName }) {
     cleanOutputDir: false,
     pretty: false,
     excludeInternal: false,
-    excludeExternal: true,
+    excludeExternals: true,
     skipErrorChecking: true,
     plugin: ['@zamiell/typedoc-plugin-not-exported'],
   });

--- a/src/build/plugins/api-docs/typedoc.js
+++ b/src/build/plugins/api-docs/typedoc.js
@@ -74,6 +74,7 @@ export async function generateTypeDocJSON({ packageName }) {
     cleanOutputDir: false,
     pretty: false,
     excludeInternal: false,
+    excludeExternal: true,
     skipErrorChecking: true,
     plugin: ['@zamiell/typedoc-plugin-not-exported'],
   });


### PR DESCRIPTION
otherwise typedoc will try to document imported node_modules