### PR TITLE
typedoc: make include folders unique

### DIFF
--- a/src/build/plugins/api-docs/typedoc.js
+++ b/src/build/plugins/api-docs/typedoc.js
@@ -59,7 +59,7 @@ export async function generateTypeDocJSON({ packageName }) {
 
   const tsConfig = {
     extends: extendsTsConfig,
-    include: absoluteResolved.map((entry) => dirname(entry)),
+    include: [...new Set(absoluteResolved.map((entry) => dirname(entry)))],
     compilerOptions: {
       baseUrl: typeInfo.dir,
       noEmitOnError: false,


### PR DESCRIPTION
this will also prevent passing too many entries to ts config include