### PR TITLE
feat: display arg flags

### DIFF
--- a/src/browser/typedoc/signature/args.gts
+++ b/src/browser/typedoc/signature/args.gts
@@ -1,7 +1,12 @@
 import { Comment, isIntrinsic, isNamedTuple, Type } from '../renderer.gts';
 
 import type { TOC } from '@ember/component/template-only';
-import type { DeclarationReflection, Reflection, SignatureReflection } from 'typedoc';
+import type {
+  DeclarationReflection,
+  Reflection,
+  ReflectionFlags,
+  SignatureReflection,
+} from 'typedoc';
 
 const not = (x: unknown) => !x;
 
@@ -26,6 +31,12 @@ export const Args: TOC<{
             <Type @info={{child.element}} />
           {{/if}}
         </span>
+
+        {{#if (getFlags child.flags)}}
+          {{! we can potentially display more flags here in the future }}
+          <Flags @flags={{child.flags}} />
+        {{/if}}
+
         {{#if (not (isIntrinsic child.type))}}
           <Type @info={{child.type}} />
         {{else if (isNamedTuple child)}}
@@ -47,7 +58,7 @@ function listifyArgs(info: DeclarationReflection | Reflection): any[] {
 
   /**
    * This object *may* have Named and Positional on them,
-   * in which case, we want to create [...Postiional, Named]
+   * in which case, we want to create [...Positional, Named]
    */
   if ('children' in info && Array.isArray(info.children)) {
     if (info.children.length <= 2) {
@@ -116,4 +127,19 @@ export function getArgs(
   if ('children' in info) {
     return getArgs(info.children);
   }
+}
+
+const Flags: TOC<{
+  Args: { flags: ReflectionFlags };
+}> = <template>
+  <span class='typedoc__arg-flags'>
+    {{#each (getFlags @flags) as |flag|}}
+      <span class='typedoc__flag'>{{flag}}</span>
+    {{/each}}
+  </span>
+</template>;
+
+function getFlags(flags: ReflectionFlags): any[] {
+  // extremely simplified logic to determine flags, for now we only interested in `isOptional`
+  return [flags?.isOptional && 'optional'].filter(Boolean);
 }

--- a/src/browser/typedoc/styles.css
+++ b/src/browser/typedoc/styles.css
@@ -81,6 +81,27 @@ section {
 }
 
 /**
+ * Argument Flags
+ */
+.typedoc__arg-flags {
+  display: flex;
+  gap: 0.25rem;
+  align-items: baseline;
+  justify-content: flex-start;
+  margin: 0.5rem 0;
+}
+
+.typedoc__arg-flags > .typedoc__flag {
+  display: inline-block;
+  margin: 0;
+  font-size: 0.75rem;
+  padding: 0 0.5rem;
+  border: 1px solid #222;
+  border-radius: var(--pico-border-radius);
+  font-family: var(--pico-font-family-monospace);
+}
+
+/**
  *
  * Component Signatures
  *


### PR DESCRIPTION
* add ability to display arg flags, for now it only does it for `isOptional` all others do not seem to be important, but if there is a need they can be added easily

![Screenshot 2025-06-29 at 8 29 40 PM](https://github.com/user-attachments/assets/82507a93-fa88-4955-b9c7-b2cc78d76427)
