### PR TITLE
add typedoc-plugin-rename-defaults plugin

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -50,7 +50,7 @@
     "@glint/core": "unstable",
     "@glint/environment-ember-loose": "unstable",
     "@glint/environment-ember-template-imports": "unstable",
-    "@glint/template": "unstable",
+    "@glint/template": "^1.6.1-unstable.f415a3e",
     "@nullvoxpopuli/eslint-configs": "^5.0.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@types/qunit": "^2.19.10",

--- a/docs-app/tests/kolay/components/component-signature-test.gts
+++ b/docs-app/tests/kolay/components/component-signature-test.gts
@@ -183,13 +183,13 @@ module('<ComponentSignature>', function (hooks) {
 
   test('default export renamed', async function (assert) {
     await render(
-    <template>
-      <ComponentSignature
-        @module="declarations/browser/samples/-private"
-        @name="classE"
-        @package="kolay"
-      />
-    </template>
+      <template>
+        <ComponentSignature
+          @module="declarations/browser/samples/-private"
+          @name="classE"
+          @package="kolay"
+        />
+      </template>
     );
 
     // Temporary -- need to figure out what async thing doesn't have a waiter

--- a/docs-app/tests/kolay/components/component-signature-test.gts
+++ b/docs-app/tests/kolay/components/component-signature-test.gts
@@ -180,4 +180,21 @@ module('<ComponentSignature>', function (hooks) {
     assert.dom().doesNotContainText('Arguments');
     assert.dom().doesNotContainText('Blocks');
   });
+
+  test('default export renamed', async function (assert) {
+    await render(
+    <template>
+      <ComponentSignature
+        @module="declarations/browser/samples/-private"
+        @name="classE"
+        @package="kolay"
+      />
+    </template>
+    );
+
+    // Temporary -- need to figure out what async thing doesn't have a waiter
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+    await waitUntil(() => (this as any).element?.textContent?.includes('classE'));
+    assert.dom().containsText('classE');
+  });
 });

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "send": "^1.2.0",
     "tracked-built-ins": "^4.0.0",
     "typedoc": "0.28.4",
+    "typedoc-plugin-rename-defaults": "^0.7.3",
     "unplugin": "^2.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@ember/test-waiters": "^4.0.0",
     "@embroider/addon-shim": "1.10.0",
     "@glimmer/component": "^2.0.0",
-    "@glint/template": "1.4.1-unstable.d17c1f1",
+    "@glint/template": "1.6.1-unstable.f415a3e",
     "common-tags": "^1.8.2",
     "decorator-transforms": "^2.3.0",
     "ember-modifier": ">= 4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       typedoc:
         specifier: 0.28.4
         version: 0.28.4(typescript@5.8.3)
+      typedoc-plugin-rename-defaults:
+        specifier: ^0.7.3
+        version: 0.7.3(typedoc@0.28.4(typescript@5.8.3))
       unplugin:
         specifier: ^2.3.2
         version: 2.3.5
@@ -204,7 +207,7 @@ importers:
         version: 3.6.0
       '@universal-ember/test-support':
         specifier: ^0.4.0
-        version: 0.4.0(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)
+        version: 0.4.0(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)
       change-case:
         specifier: ^5.4.3
         version: 5.4.4
@@ -213,16 +216,16 @@ importers:
         version: 4.0.0
       ember-async-data:
         specifier: ^2.0.0
-        version: 2.0.1(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 2.0.1(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cached-decorator-polyfill:
         specifier: ^1.0.2
-        version: 1.0.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 1.0.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-mobile-menu:
         specifier: ^5.3.0
-        version: 5.3.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 5.3.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-repl:
         specifier: 6.0.0
-        version: 6.0.0(@babel/core@7.27.4)(@glimmer/compiler@0.94.10)(@glimmer/component@2.0.0)(@glimmer/syntax@0.94.9)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+        version: 6.0.0(@babel/core@7.27.4)(@glimmer/compiler@0.94.10)(@glimmer/component@2.0.0)(@glimmer/syntax@0.94.9)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))
       ember-route-template:
         specifier: ^1.0.3
         version: 1.0.3
@@ -231,7 +234,7 @@ importers:
         version: link:..
       reactiveweb:
         specifier: ^1.4.2
-        version: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       shiki:
         specifier: ^3.4.0
         version: 3.6.0
@@ -253,25 +256,25 @@ importers:
         version: 4.0.1
       '@ember/test-helpers':
         specifier: ^5.2.1
-        version: 5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)
       '@ember/test-waiters':
         specifier: ^4.0.0
-        version: 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/compat':
         specifier: ^4.0.3
-        version: 4.1.0(@embroider/core@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(rsvp@4.8.5)
+        version: 4.1.0(@embroider/core@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(rsvp@4.8.5)
       '@embroider/core':
         specifier: ^4.0.3
-        version: 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/macros':
         specifier: ^1.17.3
-        version: 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/util':
         specifier: alpha
-        version: 1.14.0-alpha.2(@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 1.14.0-alpha.2(@glint/environment-ember-loose@2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/vite':
         specifier: ^1.1.1
-        version: 1.1.5(@embroider/core@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glint/template@1.4.1-unstable.d17c1f1)(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(terser@5.41.0)(yaml@2.8.0))
+        version: 1.1.5(@embroider/core@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glint/template@1.6.1-unstable.f415a3e)(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(terser@5.41.0)(yaml@2.8.0))
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
@@ -280,16 +283,16 @@ importers:
         version: 1.1.2
       '@glint/core':
         specifier: unstable
-        version: 1.4.1-unstable.d17c1f1(typescript@5.8.3)
+        version: 2.0.1-unstable.f415a3e(typescript@5.8.3)
       '@glint/environment-ember-loose':
         specifier: unstable
-        version: 1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))
+        version: 2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))
       '@glint/environment-ember-template-imports':
         specifier: unstable
-        version: 1.4.1-unstable.d17c1f1(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 2.0.1-unstable.f415a3e(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/environment-ember-loose@2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)
       '@glint/template':
         specifier: unstable
-        version: 1.4.1-unstable.d17c1f1
+        version: 1.6.1-unstable.f415a3e
       '@nullvoxpopuli/eslint-configs':
         specifier: ^5.0.0
         version: 5.1.2(@babel/core@7.27.4)(@babel/eslint-parser@7.27.5(@babel/core@7.27.4)(eslint@9.28.0(jiti@2.4.2)))(@babel/plugin-proposal-decorators@7.27.1(@babel/core@7.27.4))(eslint@9.28.0(jiti@2.4.2))(prettier@3.5.3)(typescript@5.8.3)
@@ -307,7 +310,7 @@ importers:
         version: 2.3.0(@babel/core@7.27.4)
       ember-auto-import:
         specifier: ^2.7.0
-        version: 2.10.0(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 2.10.0(@glint/template@1.6.1-unstable.f415a3e)
       ember-cli:
         specifier: ^6.4.0
         version: 6.4.0(handlebars@4.7.8)(underscore@1.13.7)
@@ -322,10 +325,10 @@ importers:
         version: 9.0.2
       ember-primitives:
         specifier: ^0.27.2
-        version: 0.27.2(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.27.2(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-qunit:
         specifier: ^9.0.1
-        version: 9.0.3(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@glint/template@1.4.1-unstable.d17c1f1)(qunit@2.24.1)
+        version: 9.0.3(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@glint/template@1.6.1-unstable.f415a3e)(qunit@2.24.1)
       ember-resize-observer-service:
         specifier: ^1.1.0
         version: 1.1.0
@@ -334,7 +337,7 @@ importers:
         version: 13.1.1
       ember-resources:
         specifier: ^7.0.4
-        version: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-source:
         specifier: 6.5.0-alpha.6
         version: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
@@ -1459,12 +1462,32 @@ packages:
     peerDependencies:
       typescript: '>=5.6.0'
 
+  '@glint/core@2.0.1-unstable.f415a3e':
+    resolution: {integrity: sha512-V9bWH7tMyWKc+sofW69As473dQ5bo78eW3fPkwbqGJHIn/kHaAEvtb7gRWgkvGV/ToZ/NfWUNaDxX/f2vxU87g==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.6.0'
+
   '@glint/environment-ember-loose@1.4.1-unstable.d17c1f1':
     resolution: {integrity: sha512-ATLTHSTBHn4Rf/Cn/WB+hcHo66wgHVv7xUJ8uLIRrBGIHjlb1LeTtLuqdo5u3lQ1MhZvp2o3GkpgqM+Q+roTsQ==}
     peerDependencies:
       '@glimmer/component': ^2.0.0
       '@glint/core': 1.4.1-unstable.d17c1f1
       '@glint/template': 1.4.1-unstable.d17c1f1
+      ember-cli-htmlbars: ^6.0.1
+      ember-modifier: ^3.2.7 || ^4.0.0
+    peerDependenciesMeta:
+      ember-cli-htmlbars:
+        optional: true
+      ember-modifier:
+        optional: true
+
+  '@glint/environment-ember-loose@2.0.1-unstable.f415a3e':
+    resolution: {integrity: sha512-6mowmXOXXBSiDzPNBrLq8z5deNe6WwxAteE0/crVK9mRyOo3ZHs7ilaB1O8wvGk2bz/Etns1D1g2jQBQOvKlHw==}
+    peerDependencies:
+      '@glimmer/component': ^2.0.0
+      '@glint/core': 2.0.1-unstable.f415a3e
+      '@glint/template': 1.6.1-unstable.f415a3e
       ember-cli-htmlbars: ^6.0.1
       ember-modifier: ^3.2.7 || ^4.0.0
     peerDependenciesMeta:
@@ -1480,8 +1503,18 @@ packages:
       '@glint/environment-ember-loose': 1.4.1-unstable.d17c1f1
       '@glint/template': 1.4.1-unstable.d17c1f1
 
+  '@glint/environment-ember-template-imports@2.0.1-unstable.f415a3e':
+    resolution: {integrity: sha512-wZ9QVCcyL/1rkpvEz9nyTxo4c4Df3IPOorH2eRB0K/WBUh7NhvjNtgX6xIulxqotFzXJvizOY58+smZy6H0V0g==}
+    peerDependencies:
+      '@glint/core': 2.0.1-unstable.f415a3e
+      '@glint/environment-ember-loose': 2.0.1-unstable.f415a3e
+      '@glint/template': 1.6.1-unstable.f415a3e
+
   '@glint/template@1.4.1-unstable.d17c1f1':
     resolution: {integrity: sha512-qmqQ9EkUlXV15gUVLZRr/lqfCUDdtrjj4Tu8lBbeO2hT19/b5i9Z3viuVlCxAtfGAJg8uMRJ/2weuKiBrxmsBg==}
+
+  '@glint/template@1.6.1-unstable.f415a3e':
+    resolution: {integrity: sha512-IMgGN+zZH6pahthRCqhlNE+XFoK1jLfkP17dd8srXycrJ3DPxvUDfktRcKH9ZjJZAAbo19tdCT/b//0B3jluVw==}
 
   '@glint/tsserver-plugin@1.4.1-unstable.d17c1f1':
     resolution: {integrity: sha512-m/FVTiLGX3W54GoUCQCCgzrqRp7QPB3d/GH8foJuVSZYvWk8Rj22hE3BInGN22sIIaBouGATb6E8XZbg99O6ug==}
@@ -3035,6 +3068,10 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   can-symlink@1.0.0:
     resolution: {integrity: sha512-RbsNrFyhwkx+6psk/0fK/Q9orOUr9VMxohGd8vTa4djf4TGLfblBgUfqZChrZuW0Q+mz2eBPFLusw9Jfukzmhg==}
@@ -7765,6 +7802,11 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
+  typedoc-plugin-rename-defaults@0.7.3:
+    resolution: {integrity: sha512-fDtrWZ9NcDfdGdlL865GW7uIGQXlthPscURPOhDkKUe4DBQSRRFUf33fhWw41FLlsz8ZTeSxzvvuNmh54MynFA==}
+    peerDependencies:
+      typedoc: '>=0.22.x <0.29.x'
+
   typedoc@0.28.4:
     resolution: {integrity: sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -9251,25 +9293,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@2.1.0(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember/render-modifiers@2.1.0(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.27.4)
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@glint/template': 1.4.1-unstable.d17c1f1
+      '@glint/template': 1.6.1-unstable.f415a3e
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
   '@ember/string@4.0.1': {}
 
-  '@ember/test-helpers@4.0.5(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember/test-helpers@4.0.5(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.27.4)
       dom-element-descriptors: 0.5.1
@@ -9292,10 +9334,31 @@ snapshots:
       - '@glint/template'
       - supports-color
 
+  '@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)':
+    dependencies:
+      '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@embroider/addon-shim': 1.10.0
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@simple-dom/interface': 1.4.0
+      decorator-transforms: 2.3.0(@babel/core@7.27.4)
+      dom-element-descriptors: 0.5.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
   '@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1)':
     dependencies:
       '@embroider/addon-shim': 1.10.0
       '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e)':
+    dependencies:
+      '@embroider/addon-shim': 1.10.0
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -9338,7 +9401,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/compat@4.1.0(@embroider/core@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(rsvp@4.8.5)':
+  '@embroider/compat@4.1.0(@embroider/core@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(rsvp@4.8.5)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.27.4
@@ -9349,8 +9412,8 @@ snapshots:
       '@babel/preset-env': 7.27.2(@babel/core@7.27.4)
       '@babel/runtime': 7.27.6
       '@babel/traverse': 7.27.4
-      '@embroider/core': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/core': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       '@types/babel__code-frame': 7.0.6
       assert-never: 1.4.0
       babel-import-util: 3.0.1
@@ -9430,6 +9493,42 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@embroider/core@4.1.0(@glint/template@1.6.1-unstable.f415a3e)':
+    dependencies:
+      '@babel/core': 7.27.4
+      '@babel/parser': 7.27.5
+      '@babel/traverse': 7.27.4
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@embroider/reverse-exports': 0.1.2
+      '@embroider/shared-internals': 3.0.0
+      assert-never: 1.4.0
+      babel-plugin-ember-template-compilation: 3.0.0
+      broccoli-node-api: 1.7.0
+      broccoli-persistent-filter: 3.1.3
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      debug: 4.4.1(supports-color@9.4.0)
+      escape-string-regexp: 4.0.0
+      fast-sourcemap-concat: 2.1.1
+      fs-extra: 9.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      js-string-escape: 1.0.1
+      jsdom: 25.0.1
+      lodash: 4.17.21
+      resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      resolve.exports: 2.0.3
+      semver: 7.7.2
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
   '@embroider/macros@1.16.9(@glint/template@1.4.1-unstable.d17c1f1)':
     dependencies:
       '@embroider/shared-internals': 2.8.1
@@ -9445,6 +9544,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@embroider/macros@1.16.9(@glint/template@1.6.1-unstable.f415a3e)':
+    dependencies:
+      '@embroider/shared-internals': 2.8.1
+      assert-never: 1.4.0
+      babel-import-util: 2.1.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.10
+      semver: 7.7.2
+    optionalDependencies:
+      '@glint/template': 1.6.1-unstable.f415a3e
+    transitivePeerDependencies:
+      - supports-color
+
   '@embroider/macros@1.18.0(@glint/template@1.4.1-unstable.d17c1f1)':
     dependencies:
       '@embroider/shared-internals': 3.0.0
@@ -9457,6 +9571,21 @@ snapshots:
       semver: 7.7.2
     optionalDependencies:
       '@glint/template': 1.4.1-unstable.d17c1f1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/macros@1.18.0(@glint/template@1.6.1-unstable.f415a3e)':
+    dependencies:
+      '@embroider/shared-internals': 3.0.0
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.10
+      semver: 7.7.2
+    optionalDependencies:
+      '@glint/template': 1.6.1-unstable.f415a3e
     transitivePeerDependencies:
       - supports-color
 
@@ -9517,23 +9646,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/util@1.14.0-alpha.2(@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@embroider/util@1.14.0-alpha.2(@glint/environment-ember-loose@2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@glint/environment-ember-loose': 1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))
-      '@glint/template': 1.4.1-unstable.d17c1f1
+      '@glint/environment-ember-loose': 2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))
+      '@glint/template': 1.6.1-unstable.f415a3e
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/vite@1.1.5(@embroider/core@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glint/template@1.4.1-unstable.d17c1f1)(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(terser@5.41.0)(yaml@2.8.0))':
+  '@embroider/vite@1.1.5(@embroider/core@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glint/template@1.6.1-unstable.f415a3e)(rollup@4.42.0)(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(terser@5.41.0)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.27.4
-      '@embroider/core': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/core': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/reverse-exports': 0.1.2
       '@rollup/pluginutils': 5.1.4(rollup@4.42.0)
       assert-never: 1.4.0
@@ -9885,11 +10014,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3)':
+    dependencies:
+      '@glimmer/syntax': 0.94.9
+      '@volar/kit': 2.4.12(typescript@5.8.3)
+      '@volar/language-core': 2.4.12
+      '@volar/language-server': 2.4.12
+      '@volar/language-service': 2.4.12
+      '@volar/source-map': 2.4.12
+      '@volar/test-utils': 2.4.12
+      '@volar/typescript': 2.4.12
+      computeds: 0.0.1
+      escape-string-regexp: 4.0.0
+      semver: 7.7.2
+      silent-error: 1.1.1
+      typescript: 5.8.3
+      uuid: 8.3.2
+      volar-service-html: 0.0.64(@volar/language-service@2.4.12)
+      volar-service-typescript: 0.0.64(@volar/language-service@2.4.12)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))':
     dependencies:
       '@glimmer/component': 2.0.0
       '@glint/core': 1.4.1-unstable.d17c1f1(typescript@5.8.3)
       '@glint/template': 1.4.1-unstable.d17c1f1
+    optionalDependencies:
+      ember-modifier: 4.2.2(@babel/core@7.27.4)
+
+  '@glint/environment-ember-loose@2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))':
+    dependencies:
+      '@glimmer/component': 2.0.0
+      '@glint/core': 2.0.1-unstable.f415a3e(typescript@5.8.3)
+      '@glint/template': 1.6.1-unstable.f415a3e
     optionalDependencies:
       ember-modifier: 4.2.2(@babel/core@7.27.4)
 
@@ -9900,7 +10062,16 @@ snapshots:
       '@glint/template': 1.4.1-unstable.d17c1f1
       content-tag: 3.1.3
 
+  '@glint/environment-ember-template-imports@2.0.1-unstable.f415a3e(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/environment-ember-loose@2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)':
+    dependencies:
+      '@glint/core': 2.0.1-unstable.f415a3e(typescript@5.8.3)
+      '@glint/environment-ember-loose': 2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))
+      '@glint/template': 1.6.1-unstable.f415a3e
+      content-tag: 3.1.3
+
   '@glint/template@1.4.1-unstable.d17c1f1': {}
+
+  '@glint/template@1.6.1-unstable.f415a3e': {}
 
   '@glint/tsserver-plugin@1.4.1-unstable.d17c1f1':
     dependencies:
@@ -10846,9 +11017,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@universal-ember/test-support@0.4.0(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)':
+  '@universal-ember/test-support@0.4.0(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)':
     dependencies:
-      '@ember/test-helpers': 4.0.5(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember/test-helpers': 4.0.5(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@embroider/addon-shim': 1.10.0
       decorator-transforms: 1.2.1(@babel/core@7.27.4)
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
@@ -11881,6 +12052,8 @@ snapshots:
 
   camelcase@6.3.0: {}
 
+  camelcase@8.0.0: {}
+
   can-symlink@1.0.0:
     dependencies:
       tmp: 0.0.28
@@ -12407,7 +12580,18 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-auto-import@2.10.0(@glint/template@1.4.1-unstable.d17c1f1):
+  ember-async-data@2.0.1(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+    dependencies:
+      '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@embroider/addon-shim': 1.10.0
+      decorator-transforms: 2.3.0(@babel/core@7.27.4)
+      ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  ember-auto-import@2.10.0(@glint/template@1.6.1-unstable.f415a3e):
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.27.4)
@@ -12415,7 +12599,7 @@ snapshots:
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.27.4)
       '@babel/plugin-transform-class-static-block': 7.27.1(@babel/core@7.27.4)
       '@babel/preset-env': 7.27.2(@babel/core@7.27.4)
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/shared-internals': 2.9.0
       babel-loader: 8.4.1(@babel/core@7.27.4)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
@@ -12460,9 +12644,9 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       '@glimmer/tracking': 1.1.2
       babel-import-util: 1.4.1
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.27.4)
@@ -12766,7 +12950,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-concurrency@4.0.4(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1):
+  ember-concurrency@4.0.4(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e):
     dependencies:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
@@ -12774,7 +12958,7 @@ snapshots:
       '@embroider/addon-shim': 1.10.0
       decorator-transforms: 1.2.1(@babel/core@7.27.4)
     optionalDependencies:
-      '@glint/template': 1.4.1-unstable.d17c1f1
+      '@glint/template': 1.6.1-unstable.f415a3e
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -12817,30 +13001,30 @@ snapshots:
       - supports-color
       - typescript
 
-  ember-gesture-modifiers@6.1.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-gesture-modifiers@6.1.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@embroider/addon-shim': 1.10.0
       decorator-transforms: 2.3.0(@babel/core@7.27.4)
       ember-modifier: 4.2.2(@babel/core@7.27.4)
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
-      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
+      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-mobile-menu@5.3.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-mobile-menu@5.3.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      '@ember/test-waiters': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/addon-shim': 1.10.0
       '@glimmer/component': 2.0.0
       '@glimmer/tracking': 1.1.2
       decorator-transforms: 2.3.0(@babel/core@7.27.4)
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      ember-concurrency: 4.0.4(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
-      ember-gesture-modifiers: 6.1.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      ember-on-resize-modifier: 2.0.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-concurrency: 4.0.4(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)
+      ember-gesture-modifiers: 6.1.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-on-resize-modifier: 2.0.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)
       ember-set-body-class: 1.0.2
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
       tracked-built-ins: 4.0.0(@babel/core@7.27.4)
@@ -12871,9 +13055,9 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-on-resize-modifier@2.0.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1):
+  ember-on-resize-modifier@2.0.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e):
     dependencies:
-      ember-auto-import: 2.10.0(@glint/template@1.4.1-unstable.d17c1f1)
+      ember-auto-import: 2.10.0(@glint/template@1.6.1-unstable.f415a3e)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-modifier: 4.2.2(@babel/core@7.27.4)
@@ -12891,29 +13075,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-primitives@0.27.2(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-primitives@0.27.2(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/runtime': 7.27.6
-      '@ember/test-waiters': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.16.9(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/macros': 1.16.9(@glint/template@1.6.1-unstable.f415a3e)
       '@floating-ui/dom': 1.7.1
       '@glimmer/component': 2.0.0
       '@glimmer/tracking': 1.1.2
       decorator-transforms: 2.3.0(@babel/core@7.27.4)
       ember-element-helper: 0.8.8
       ember-modifier: 4.2.2(@babel/core@7.27.4)
-      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
       form-data-utils: 0.6.0
-      reactiveweb: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      reactiveweb: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       should-handle-link: 1.3.0
       tabster: 8.5.5
       tracked-built-ins: 3.4.0(@babel/core@7.27.4)
       tracked-toolbox: 2.0.0(@babel/core@7.27.4)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
     optionalDependencies:
-      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
-      '@glint/template': 1.4.1-unstable.d17c1f1
+      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)
+      '@glint/template': 1.6.1-unstable.f415a3e
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -12949,6 +13133,17 @@ snapshots:
       '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
       '@embroider/addon-shim': 1.10.0
       '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      qunit: 2.24.1
+      qunit-theme-ember: 1.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  ember-qunit@9.0.3(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@glint/template@1.6.1-unstable.f415a3e)(qunit@2.24.1):
+    dependencies:
+      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)
+      '@embroider/addon-shim': 1.10.0
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       qunit: 2.24.1
       qunit-theme-ember: 1.0.0
     transitivePeerDependencies:
@@ -12993,6 +13188,44 @@ snapshots:
       - '@glimmer/component'
       - supports-color
 
+  ember-repl@6.0.0(@babel/core@7.27.4)(@glimmer/compiler@0.94.10)(@glimmer/component@2.0.0)(@glimmer/syntax@0.94.9)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))):
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/standalone': 7.27.6
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.9(@glint/template@1.6.1-unstable.f415a3e)
+      babel-import-util: 3.0.1
+      babel-plugin-ember-template-compilation: 2.4.1
+      broccoli-file-creator: 2.1.1
+      change-case: 5.4.4
+      common-tags: 1.8.2
+      content-tag: 3.1.3
+      decorator-transforms: 2.3.0(@babel/core@7.27.4)
+      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      line-column: 1.0.2
+      magic-string: 0.30.17
+      mdast: 3.0.0
+      parse-static-imports: 1.1.0
+      reactiveweb: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      rehype-raw: 6.1.1
+      rehype-stringify: 9.0.4
+      remark-gfm: 3.0.1
+      remark-parse: 10.0.2
+      remark-rehype: 10.1.0
+      unified: 10.1.2
+      unist-util-visit: 5.0.0
+      uuid: 10.0.0
+      vfile: 6.0.3
+    optionalDependencies:
+      '@glimmer/compiler': 0.94.10
+      '@glimmer/syntax': 0.94.9
+      '@glint/template': 1.6.1-unstable.f415a3e
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glimmer/component'
+      - supports-color
+
   ember-resize-observer-service@1.1.0:
     dependencies:
       ember-cli-babel: 7.26.11
@@ -13011,6 +13244,17 @@ snapshots:
       '@embroider/addon-shim': 1.10.0
       '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
       '@glint/template': 1.4.1-unstable.d17c1f1
+      ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
+    optionalDependencies:
+      '@glimmer/component': 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+    dependencies:
+      '@embroider/addon-shim': 1.10.0
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@glint/template': 1.6.1-unstable.f415a3e
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
       '@glimmer/component': 2.0.0
@@ -16411,6 +16655,21 @@ snapshots:
       - ember-source
       - supports-color
 
+  reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+    dependencies:
+      '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
+      '@embroider/addon-shim': 1.10.0
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
+      decorator-transforms: 2.3.0(@babel/core@7.27.4)
+      ember-async-data: 2.0.1(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glimmer/component'
+      - '@glint/template'
+      - ember-source
+      - supports-color
+
   read-ini-file@4.0.0:
     dependencies:
       ini: 3.0.1
@@ -17773,6 +18032,11 @@ snapshots:
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
+
+  typedoc-plugin-rename-defaults@0.7.3(typedoc@0.28.4(typescript@5.8.3)):
+    dependencies:
+      camelcase: 8.0.0
+      typedoc: 0.28.4(typescript@5.8.3)
 
   typedoc@0.28.4(typescript@5.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   ember-repl: 6.0.0
   ember-source: 6.5.0-alpha.6
 
-packageExtensionsChecksum: ad075fa7f4ae4d75e3fe6c91b7b594c2
+packageExtensionsChecksum: sha256-I4/i17OOf0WifUwpGYE/KCRs9xMfb6hiQlSpKvR/tsk=
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   ember-repl: 6.0.0
   ember-source: 6.5.0-alpha.6
 
-packageExtensionsChecksum: sha256-I4/i17OOf0WifUwpGYE/KCRs9xMfb6hiQlSpKvR/tsk=
+packageExtensionsChecksum: ad075fa7f4ae4d75e3fe6c91b7b594c2
 
 importers:
 
@@ -20,7 +20,7 @@ importers:
     dependencies:
       '@ember/test-waiters':
         specifier: ^4.0.0
-        version: 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/addon-shim':
         specifier: 1.10.0
         version: 1.10.0
@@ -28,8 +28,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@glint/template':
-        specifier: 1.4.1-unstable.d17c1f1
-        version: 1.4.1-unstable.d17c1f1
+        specifier: 1.6.1-unstable.f415a3e
+        version: 1.6.1-unstable.f415a3e
       common-tags:
         specifier: ^1.8.2
         version: 1.8.2
@@ -41,13 +41,13 @@ importers:
         version: 4.2.2(@babel/core@7.27.4)
       ember-primitives:
         specifier: ^0.32.0
-        version: 0.32.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.32.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-repl:
         specifier: 6.0.0
-        version: 6.0.0(@babel/core@7.27.4)(@glimmer/compiler@0.94.10)(@glimmer/component@2.0.0)(@glimmer/syntax@0.94.9)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))
+        version: 6.0.0(@babel/core@7.27.4)(@glimmer/compiler@0.94.10)(@glimmer/component@2.0.0)(@glimmer/syntax@0.94.9)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))
       ember-resources:
         specifier: ^7.0.4
-        version: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       globby:
         specifier: ^14.1.0
         version: 14.1.0
@@ -59,7 +59,7 @@ importers:
         version: 5.0.0
       reactiveweb:
         specifier: ^1.4.2
-        version: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       send:
         specifier: ^1.2.0
         version: 1.2.0
@@ -99,16 +99,16 @@ importers:
         version: 1.1.3
       '@embroider/addon-dev':
         specifier: 8.0.1
-        version: 8.0.1(@glint/template@1.4.1-unstable.d17c1f1)(rollup@4.42.0)
+        version: 8.0.1(@glint/template@1.6.1-unstable.f415a3e)(rollup@4.42.0)
       '@glint/core':
         specifier: 1.4.1-unstable.d17c1f1
         version: 1.4.1-unstable.d17c1f1(typescript@5.8.3)
       '@glint/environment-ember-loose':
         specifier: 1.4.1-unstable.d17c1f1
-        version: 1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))
+        version: 1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))
       '@glint/environment-ember-template-imports':
         specifier: 1.4.1-unstable.d17c1f1
-        version: 1.4.1-unstable.d17c1f1(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.4.1-unstable.d17c1f1)
+        version: 1.4.1-unstable.d17c1f1(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)
       '@glint/tsserver-plugin':
         specifier: 1.4.1-unstable.d17c1f1
         version: 1.4.1-unstable.d17c1f1
@@ -144,7 +144,7 @@ importers:
         version: 9.1.2
       ember-qunit:
         specifier: ^9.0.1
-        version: 9.0.3(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@glint/template@1.4.1-unstable.d17c1f1)(qunit@2.24.1)
+        version: 9.0.3(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@glint/template@1.6.1-unstable.f415a3e)(qunit@2.24.1)
       ember-source:
         specifier: 6.5.0-alpha.6
         version: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
@@ -291,7 +291,7 @@ importers:
         specifier: unstable
         version: 2.0.1-unstable.f415a3e(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/environment-ember-loose@2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)
       '@glint/template':
-        specifier: unstable
+        specifier: ^1.6.1-unstable.f415a3e
         version: 1.6.1-unstable.f415a3e
       '@nullvoxpopuli/eslint-configs':
         specifier: ^5.0.0
@@ -1509,9 +1509,6 @@ packages:
       '@glint/core': 2.0.1-unstable.f415a3e
       '@glint/environment-ember-loose': 2.0.1-unstable.f415a3e
       '@glint/template': 1.6.1-unstable.f415a3e
-
-  '@glint/template@1.4.1-unstable.d17c1f1':
-    resolution: {integrity: sha512-qmqQ9EkUlXV15gUVLZRr/lqfCUDdtrjj4Tu8lBbeO2hT19/b5i9Z3viuVlCxAtfGAJg8uMRJ/2weuKiBrxmsBg==}
 
   '@glint/template@1.6.1-unstable.f415a3e':
     resolution: {integrity: sha512-IMgGN+zZH6pahthRCqhlNE+XFoK1jLfkP17dd8srXycrJ3DPxvUDfktRcKH9ZjJZAAbo19tdCT/b//0B3jluVw==}
@@ -9321,19 +9318,6 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)':
-    dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@simple-dom/interface': 1.4.0
-      decorator-transforms: 2.3.0(@babel/core@7.27.4)
-      dom-element-descriptors: 0.5.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
   '@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)':
     dependencies:
       '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
@@ -9347,14 +9331,6 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1)':
-    dependencies:
-      '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-
   '@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e)':
     dependencies:
       '@embroider/addon-shim': 1.10.0
@@ -9363,9 +9339,9 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@embroider/addon-dev@8.0.1(@glint/template@1.4.1-unstable.d17c1f1)(rollup@4.42.0)':
+  '@embroider/addon-dev@8.0.1(@glint/template@1.6.1-unstable.f415a3e)(rollup@4.42.0)':
     dependencies:
-      '@embroider/core': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/core': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@rollup/pluginutils': 5.1.4(rollup@4.42.0)
       content-tag: 3.1.3
       execa: 5.1.1
@@ -9457,42 +9433,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/core@4.1.0(@glint/template@1.4.1-unstable.d17c1f1)':
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/parser': 7.27.5
-      '@babel/traverse': 7.27.4
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@embroider/reverse-exports': 0.1.2
-      '@embroider/shared-internals': 3.0.0
-      assert-never: 1.4.0
-      babel-plugin-ember-template-compilation: 3.0.0
-      broccoli-node-api: 1.7.0
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      debug: 4.4.1(supports-color@9.4.0)
-      escape-string-regexp: 4.0.0
-      fast-sourcemap-concat: 2.1.1
-      fs-extra: 9.1.0
-      fs-tree-diff: 2.0.1
-      handlebars: 4.7.8
-      js-string-escape: 1.0.1
-      jsdom: 25.0.1
-      lodash: 4.17.21
-      resolve: 1.22.10
-      resolve-package-path: 4.0.3
-      resolve.exports: 2.0.3
-      semver: 7.7.2
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-
   '@embroider/core@4.1.0(@glint/template@1.6.1-unstable.f415a3e)':
     dependencies:
       '@babel/core': 7.27.4
@@ -9529,21 +9469,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/macros@1.16.9(@glint/template@1.4.1-unstable.d17c1f1)':
-    dependencies:
-      '@embroider/shared-internals': 2.8.1
-      assert-never: 1.4.0
-      babel-import-util: 2.1.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.10
-      semver: 7.7.2
-    optionalDependencies:
-      '@glint/template': 1.4.1-unstable.d17c1f1
-    transitivePeerDependencies:
-      - supports-color
-
   '@embroider/macros@1.16.9(@glint/template@1.6.1-unstable.f415a3e)':
     dependencies:
       '@embroider/shared-internals': 2.8.1
@@ -9556,21 +9481,6 @@ snapshots:
       semver: 7.7.2
     optionalDependencies:
       '@glint/template': 1.6.1-unstable.f415a3e
-    transitivePeerDependencies:
-      - supports-color
-
-  '@embroider/macros@1.18.0(@glint/template@1.4.1-unstable.d17c1f1)':
-    dependencies:
-      '@embroider/shared-internals': 3.0.0
-      assert-never: 1.4.0
-      babel-import-util: 3.0.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.10
-      semver: 7.7.2
-    optionalDependencies:
-      '@glint/template': 1.4.1-unstable.d17c1f1
     transitivePeerDependencies:
       - supports-color
 
@@ -10039,11 +9949,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))':
+  '@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))':
     dependencies:
       '@glimmer/component': 2.0.0
       '@glint/core': 1.4.1-unstable.d17c1f1(typescript@5.8.3)
-      '@glint/template': 1.4.1-unstable.d17c1f1
+      '@glint/template': 1.6.1-unstable.f415a3e
     optionalDependencies:
       ember-modifier: 4.2.2(@babel/core@7.27.4)
 
@@ -10055,11 +9965,11 @@ snapshots:
     optionalDependencies:
       ember-modifier: 4.2.2(@babel/core@7.27.4)
 
-  '@glint/environment-ember-template-imports@1.4.1-unstable.d17c1f1(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.4.1-unstable.d17c1f1)':
+  '@glint/environment-ember-template-imports@1.4.1-unstable.d17c1f1(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/environment-ember-loose@1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)':
     dependencies:
       '@glint/core': 1.4.1-unstable.d17c1f1(typescript@5.8.3)
-      '@glint/environment-ember-loose': 1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))
-      '@glint/template': 1.4.1-unstable.d17c1f1
+      '@glint/environment-ember-loose': 1.4.1-unstable.d17c1f1(@glimmer/component@2.0.0)(@glint/core@1.4.1-unstable.d17c1f1(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))
+      '@glint/template': 1.6.1-unstable.f415a3e
       content-tag: 3.1.3
 
   '@glint/environment-ember-template-imports@2.0.1-unstable.f415a3e(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/environment-ember-loose@2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4)))(@glint/template@1.6.1-unstable.f415a3e)':
@@ -10068,8 +9978,6 @@ snapshots:
       '@glint/environment-ember-loose': 2.0.1-unstable.f415a3e(@glimmer/component@2.0.0)(@glint/core@2.0.1-unstable.f415a3e(typescript@5.8.3))(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))
       '@glint/template': 1.6.1-unstable.f415a3e
       content-tag: 3.1.3
-
-  '@glint/template@1.4.1-unstable.d17c1f1': {}
 
   '@glint/template@1.6.1-unstable.f415a3e': {}
 
@@ -12569,17 +12477,6 @@ snapshots:
 
   electron-to-chromium@1.5.165: {}
 
-  ember-async-data@2.0.1(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
-    dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@embroider/addon-shim': 1.10.0
-      decorator-transforms: 2.3.0(@babel/core@7.27.4)
-      ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
   ember-async-data@2.0.1(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
@@ -13102,41 +12999,30 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-primitives@0.32.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-primitives@0.32.0(@babel/core@7.27.4)(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-modifier@4.2.2(@babel/core@7.27.4))(ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)))(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/runtime': 7.27.6
-      '@ember/test-waiters': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@ember/test-waiters': 4.1.0(@glint/template@1.6.1-unstable.f415a3e)
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
+      '@embroider/macros': 1.18.0(@glint/template@1.6.1-unstable.f415a3e)
       '@floating-ui/dom': 1.7.1
       '@glimmer/component': 2.0.0
       decorator-transforms: 2.3.0(@babel/core@7.27.4)
       ember-element-helper: 0.8.8
       ember-modifier: 4.2.2(@babel/core@7.27.4)
-      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
       form-data-utils: 0.6.0
-      reactiveweb: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
+      reactiveweb: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       should-handle-link: 1.3.0
       tabster: 8.5.5
       tracked-built-ins: 4.0.0(@babel/core@7.27.4)
       tracked-toolbox: 2.0.0(@babel/core@7.27.4)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
     optionalDependencies:
-      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
-      '@glint/template': 1.4.1-unstable.d17c1f1
+      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e)
+      '@glint/template': 1.6.1-unstable.f415a3e
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
-
-  ember-qunit@9.0.3(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1))(@glint/template@1.4.1-unstable.d17c1f1)(qunit@2.24.1):
-    dependencies:
-      '@ember/test-helpers': 5.2.2(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)
-      '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
-      qunit: 2.24.1
-      qunit-theme-ember: 1.0.0
-    transitivePeerDependencies:
-      - '@glint/template'
       - supports-color
 
   ember-qunit@9.0.3(@ember/test-helpers@5.2.2(@babel/core@7.27.4)(@glint/template@1.6.1-unstable.f415a3e))(@glint/template@1.6.1-unstable.f415a3e)(qunit@2.24.1):
@@ -13148,44 +13034,6 @@ snapshots:
       qunit-theme-ember: 1.0.0
     transitivePeerDependencies:
       - '@glint/template'
-      - supports-color
-
-  ember-repl@6.0.0(@babel/core@7.27.4)(@glimmer/compiler@0.94.10)(@glimmer/component@2.0.0)(@glimmer/syntax@0.94.9)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))):
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/standalone': 7.27.6
-      '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.9(@glint/template@1.4.1-unstable.d17c1f1)
-      babel-import-util: 3.0.1
-      babel-plugin-ember-template-compilation: 2.4.1
-      broccoli-file-creator: 2.1.1
-      change-case: 5.4.4
-      common-tags: 1.8.2
-      content-tag: 3.1.3
-      decorator-transforms: 2.3.0(@babel/core@7.27.4)
-      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
-      line-column: 1.0.2
-      magic-string: 0.30.17
-      mdast: 3.0.0
-      parse-static-imports: 1.1.0
-      reactiveweb: 1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      rehype-raw: 6.1.1
-      rehype-stringify: 9.0.4
-      remark-gfm: 3.0.1
-      remark-parse: 10.0.2
-      remark-rehype: 10.1.0
-      unified: 10.1.2
-      unist-util-visit: 5.0.0
-      uuid: 10.0.0
-      vfile: 6.0.3
-    optionalDependencies:
-      '@glimmer/compiler': 0.94.10
-      '@glimmer/syntax': 0.94.9
-      '@glint/template': 1.4.1-unstable.d17c1f1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glimmer/component'
       - supports-color
 
   ember-repl@6.0.0(@babel/core@7.27.4)(@glimmer/compiler@0.94.10)(@glimmer/component@2.0.0)(@glimmer/syntax@0.94.9)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))(reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))):
@@ -13236,17 +13084,6 @@ snapshots:
   ember-resolver@13.1.1:
     dependencies:
       ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-resources@7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
-    dependencies:
-      '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@glint/template': 1.4.1-unstable.d17c1f1
-      ember-source: 6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
-    optionalDependencies:
-      '@glimmer/component': 2.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16639,21 +16476,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-
-  reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.4.1-unstable.d17c1f1))(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
-    dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.4.1-unstable.d17c1f1)
-      '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.18.0(@glint/template@1.4.1-unstable.d17c1f1)
-      decorator-transforms: 2.3.0(@babel/core@7.27.4)
-      ember-async-data: 2.0.1(@babel/core@7.27.4)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
-      ember-resources: 7.0.4(@glimmer/component@2.0.0)(@glint/template@1.4.1-unstable.d17c1f1)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glimmer/component'
-      - '@glint/template'
-      - ember-source
-      - supports-color
 
   reactiveweb@1.5.0(@babel/core@7.27.4)(@ember/test-waiters@4.1.0(@glint/template@1.6.1-unstable.f415a3e))(@glimmer/component@2.0.0)(@glint/template@1.6.1-unstable.f415a3e)(ember-source@6.5.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:

--- a/src/browser/samples/-private/component.gts
+++ b/src/browser/samples/-private/component.gts
@@ -73,4 +73,4 @@ export const TemplateOnlyD: TOC<{
   };
 }> = <template>hi</template>;
 
-export default class classE extends Component<SignatureA> {};
+export default class classE extends Component<SignatureA> {}

--- a/src/browser/samples/-private/component.gts
+++ b/src/browser/samples/-private/component.gts
@@ -72,3 +72,5 @@ export const TemplateOnlyD: TOC<{
     namedBlockB: [boolean];
   };
 }> = <template>hi</template>;
+
+export default class classE extends Component<SignatureA> {};

--- a/src/browser/typedoc/renderer.gts
+++ b/src/browser/typedoc/renderer.gts
@@ -121,6 +121,7 @@ export const Comment: TOC<{
 const isIgnored = (name: string) => ['__type', 'TOC', 'TemplateOnlyComponent'].includes(name);
 const isConst = (x: { flags: { isConst: boolean } }) => x.flags.isConst;
 const not = (x: unknown) => !x;
+const or = (...args: unknown) => args.find(x => !!x);
 
 const Declaration: TOC<{
   Args: {
@@ -251,7 +252,7 @@ const Reference: TOC<{ info: ReferenceType }> = <template>
   {{else}}
     <div class='typedoc__reference'>
       {{#if (not (isIgnored @info.name))}}
-        <div class='typedoc__reference__name'>{{@info.name}}</div>
+        <div class='typedoc__reference__name'>{{or @info.reflection.name @info.name}}</div>
       {{/if}}
       {{#if @info.typeArguments.length}}
         <div class='typedoc__reference__typeArguments'>

--- a/src/browser/typedoc/renderer.gts
+++ b/src/browser/typedoc/renderer.gts
@@ -121,7 +121,7 @@ export const Comment: TOC<{
 const isIgnored = (name: string) => ['__type', 'TOC', 'TemplateOnlyComponent'].includes(name);
 const isConst = (x: { flags: { isConst: boolean } }) => x.flags.isConst;
 const not = (x: unknown) => !x;
-const or = (...args: unknown) => args.find(x => !!x);
+const or = (...args: unknown) => args.find((x) => !!x);
 
 const Declaration: TOC<{
   Args: {

--- a/src/build/plugins/api-docs/typedoc.js
+++ b/src/build/plugins/api-docs/typedoc.js
@@ -97,6 +97,7 @@ export async function generateTypeDocJSON({ packageName }) {
     // All types to be referenced in docs must be exported.
     // This plugin does not work with the latest typedoc
     // plugin: ['@zamiell/typedoc-plugin-not-exported'],
+    plugin: ['typedoc-plugin-rename-defaults'],
   });
 
   const project = await typedocApp.convert();


### PR DESCRIPTION
this is breaking. because the exported name is now the type name, and not `default`.
e.g
```
<ComponentSignature
        @module="declarations/browser/samples/-private"
        @name="default"
        @package="kolay"
      />
```
will not work anymore