### PR TITLE
Fix: apply root-level meta.jsonc order config

### DIFF
--- a/src/build/plugins/markdown-pages/sort.js
+++ b/src/build/plugins/markdown-pages/sort.js
@@ -11,7 +11,7 @@ function uniq(arr) {
  * @returns {string}
  */
 function findPathForJsonc(path) {
-  return path.replace(/\/meta\.jsonc?$/, '');
+  return path.replace(/\/?meta\.jsonc?$/, '');
 }
 
 /**
@@ -134,7 +134,7 @@ export function sortTree(tree, configs, parents = []) {
   tree.pages.map((subTree) => sortTree(subTree, configs, [...parents, tree.path]));
 
   if (configs.length > 0) {
-    const subPath = `${[...parents, tree.path].join('/')}`.replace(/^root\//, '');
+    const subPath = `${[...parents, tree.path].join('/')}`.replace(/^root\/?/, '');
     const config = configs
       .filter(Boolean)
       .find((config) => findPathForJsonc(config.path) === subPath)?.config;


### PR DESCRIPTION
## Summary

Root-level `meta.jsonc` `order` is silently ignored — sort falls back to whatever `betterSort` produces (effectively alphabetical via `localeCompare`, often unhelpful). Nested `meta.jsonc` files work fine; only the root case is broken.

## Reproduction

In any group, place a `meta.jsonc` at the group root:

```jsonc
// docs/meta.jsonc
{ "order": ["getting-started", "ui-schema", "data-schema"] }
```

With folders `getting-started/`, `ui-schema/`, `data-schema/` each containing an `index.md`. Expected: clicking the group lands on `getting-started`. Actual: lands on whatever sorts first alphabetically (in my repro, `ui-schema/overview.md`).

## Root cause

In [`src/build/plugins/markdown-pages/sort.js`](https://github.com/universal-ember/kolay/blob/main/src/build/plugins/markdown-pages/sort.js), `sortTree` matches a config to a folder via:

```js
const subPath = `${[...parents, tree.path].join('/')}`.replace(/^root\//, '');
const config = configs.find((c) => findPathForJsonc(c.path) === subPath)?.config;

function findPathForJsonc(path) {
  return path.replace(/\/meta\.jsonc?$/, '');
}
```

For the root tree, `parents=[]` and `tree.path='root'`, so the joined string is just `'root'` — no trailing slash to strip, `subPath` stays `'root'`. Meanwhile the config path at the root is `'meta.jsonc'` (no leading slash), and `findPathForJsonc('meta.jsonc')` returns `'meta.jsonc'` (no leading slash to strip). They never match.

For nested folders both regexes naturally hit their slash (e.g. `'root/ui-schema'` → `'ui-schema'`, `'ui-schema/meta.jsonc'` → `'ui-schema'`), so nested configs work.

## Fix

Make the slash optional in both regexes (two `?` characters):

```diff
- return path.replace(/\/meta\.jsonc?$/, '');
+ return path.replace(/\/?meta\.jsonc?$/, '');
```
```diff
- ...replace(/^root\//, '');
+ ...replace(/^root\/?/, '');
```

Now `findPathForJsonc('meta.jsonc')` returns `''`, `subPath` for the root tree becomes `''`, and they match.

## Tested

Verified locally against my consumer (kolay@5.1.4) — the patched version correctly applies root-level order. Without the patch, the sidebar shows alphabetical order; with it, the configured order is honored.

No test in this PR — happy to add one if you point me at the right test-app to wire it through (`test-apps/markdown-only` looked closest but I didn't want to guess the convention).