### PR TITLE
Extract compiledDoc from selected; document rendering pages yourself

### DIFF
--- a/docs-app/src/templates/usage/rendering-pages.gjs.md
+++ b/docs-app/src/templates/usage/rendering-pages.gjs.md
@@ -70,7 +70,7 @@ import Component from "@glimmer/component";
 import { compiledDoc } from "kolay";
 
 export default class MyDocPage extends Component {
-  doc = compiledDoc(this, () =>
+  doc = compiledDoc(() =>
     fetch(`/api/docs/${this.args.slug}.md`).then((response) => response.text()),
   );
 

--- a/docs-app/src/templates/usage/rendering-pages.gjs.md
+++ b/docs-app/src/templates/usage/rendering-pages.gjs.md
@@ -34,6 +34,56 @@ export default Route(
 );
 ```
 
+### Rendering the current page yourself
+
+`<Page />` is a thin wrapper around the [`selected`](/Runtime/util/selected.md) store. If its blocks don't give you enough control (custom loading UI, combining states, extra chrome around the prose), you can use the store directly:
+
+```gjs
+import Component from "@glimmer/component";
+import { selected } from "kolay";
+
+export default class MyPage extends Component {
+  get current() {
+    return selected(this);
+  }
+
+  <template>
+    {{#if this.current.hasError}}
+      <div role="alert">{{this.current.error}}</div>
+    {{else if this.current.isPending}}
+      <div role="status">loading…</div>
+    {{/if}}
+
+    {{#if this.current.prose}}
+      <this.current.prose />
+    {{/if}}
+  </template>
+}
+```
+
+### Rendering documents you fetch yourself
+
+The current-page behaviors (async loading, compiling with your site-wide config, keeping the previous document while a new one loads, test-`settled()` integration) are available for _any_ document via [`compiledDoc`](/Runtime/util/compiled-doc.md) — useful when your content comes from an API, a CMS, or a dynamic `import()`:
+
+```gjs
+import Component from "@glimmer/component";
+import { compiledDoc } from "kolay";
+
+export default class MyDocPage extends Component {
+  doc = compiledDoc(this, () =>
+    fetch(`/api/docs/${this.args.slug}.md`).then((response) => response.text()),
+  );
+
+  <template>
+    {{#if this.doc.prose}}
+      <this.doc.prose />
+    {{/if}}
+  </template>
+}
+```
+
+### Rendering a page within a page
+
 If you want to render a page within a page, you can do that with the `Compiled` helper. This will use your site-wide configuration so all the remark plugins, rehype plugins, extra modules, etc will all be used when you use `Compiled`.
 
 ```gjs live preview no-shadow

--- a/docs-app/tests/kolay/services/compiled-doc-test.gts
+++ b/docs-app/tests/kolay/services/compiled-doc-test.gts
@@ -1,5 +1,4 @@
 import { tracked } from '@glimmer/tracking';
-import { setOwner } from '@ember/owner';
 import { render, settled, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest, setupRenderingTest } from 'ember-qunit';
@@ -32,11 +31,7 @@ module('compiledDoc', function (hooks) {
   setupKolay(hooks);
 
   test('renders a markdown string', async function (assert) {
-    const context = {};
-
-    setOwner(context, this.owner);
-
-    const doc = compiledDoc(context, () => `# Hello there`);
+    const doc = compiledDoc(() => `# Hello there`);
 
     await render(
       <template>
@@ -52,11 +47,7 @@ module('compiledDoc', function (hooks) {
   });
 
   test('renders a markdown string fetched asynchronously', async function (assert) {
-    const context = {};
-
-    setOwner(context, this.owner);
-
-    const doc = compiledDoc(context, () => Promise.resolve(`# From afar`));
+    const doc = compiledDoc(() => Promise.resolve(`# From afar`));
 
     await render(
       <template>
@@ -74,15 +65,11 @@ module('compiledDoc', function (hooks) {
   });
 
   test('renders a module with a default-exported component', async function (assert) {
-    const context = {};
-
-    setOwner(context, this.owner);
-
     const AlreadyCompiled = <template>
       <output>general kenobi</output>
     </template>;
 
-    const doc = compiledDoc(context, () => Promise.resolve({ default: AlreadyCompiled }));
+    const doc = compiledDoc(() => Promise.resolve({ default: AlreadyCompiled }));
 
     await render(
       <template>
@@ -107,11 +94,7 @@ module('compiledDoc', function (hooks) {
     };
 
     const state = new State();
-    const context = {};
-
-    setOwner(context, this.owner);
-
-    const doc = compiledDoc(context, () => Promise.resolve(sources[state.name] ?? ''));
+    const doc = compiledDoc(() => Promise.resolve(sources[state.name] ?? ''));
 
     await render(
       <template>
@@ -144,11 +127,7 @@ module('compiledDoc', function (hooks) {
     }
 
     const state = new State();
-    const context = {};
-
-    setOwner(context, this.owner);
-
-    const doc = compiledDoc(context, () => (state.ready ? `# Now ready` : undefined));
+    const doc = compiledDoc(() => (state.ready ? `# Now ready` : undefined));
 
     await render(
       <template>

--- a/docs-app/tests/kolay/services/compiled-doc-test.gts
+++ b/docs-app/tests/kolay/services/compiled-doc-test.gts
@@ -1,0 +1,173 @@
+import { tracked } from '@glimmer/tracking';
+import { setOwner } from '@ember/owner';
+import { render, settled, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest, setupRenderingTest } from 'ember-qunit';
+
+import { compiledDoc } from 'kolay';
+
+import { setupKolay } from 'kolay/test-support';
+
+module('compiledDoc | docs pages', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('the compiledDoc page renders, including its live demo', async function (assert) {
+    await visit('/Runtime/util/compiled-doc.md');
+
+    assert.dom('[data-page-error]').doesNotExist();
+    assert.dom('h1').containsText('compiledDoc');
+    assert.dom().containsText('even live codefences work');
+  });
+
+  test('the selected page renders', async function (assert) {
+    await visit('/Runtime/util/selected.md');
+
+    assert.dom('[data-page-error]').doesNotExist();
+    assert.dom('h1').containsText('selected');
+  });
+});
+
+module('compiledDoc', function (hooks) {
+  setupRenderingTest(hooks);
+  setupKolay(hooks);
+
+  test('renders a markdown string', async function (assert) {
+    const context = {};
+
+    setOwner(context, this.owner);
+
+    const doc = compiledDoc(context, () => `# Hello there`);
+
+    await render(
+      <template>
+        {{#if doc.prose}}
+          <doc.prose />
+        {{/if}}
+      </template>
+    );
+
+    assert.dom('h1').containsText('Hello there');
+    assert.true(doc.isReady);
+    assert.false(doc.hasError);
+  });
+
+  test('renders a markdown string fetched asynchronously', async function (assert) {
+    const context = {};
+
+    setOwner(context, this.owner);
+
+    const doc = compiledDoc(context, () => Promise.resolve(`# From afar`));
+
+    await render(
+      <template>
+        {{#if doc.isPending}}
+          <div data-pending>loading</div>
+        {{/if}}
+        {{#if doc.prose}}
+          <doc.prose />
+        {{/if}}
+      </template>
+    );
+
+    assert.dom('h1').containsText('From afar');
+    assert.dom('[data-pending]').doesNotExist();
+  });
+
+  test('renders a module with a default-exported component', async function (assert) {
+    const context = {};
+
+    setOwner(context, this.owner);
+
+    const AlreadyCompiled = <template>
+      <output>general kenobi</output>
+    </template>;
+
+    const doc = compiledDoc(context, () => Promise.resolve({ default: AlreadyCompiled }));
+
+    await render(
+      <template>
+        {{#if doc.prose}}
+          <doc.prose />
+        {{/if}}
+      </template>
+    );
+
+    assert.dom('output').containsText('general kenobi');
+    assert.strictEqual(doc.prose, AlreadyCompiled);
+  });
+
+  test('reloads when tracked data read in the load function changes, keeping the previous document while loading', async function (assert) {
+    class State {
+      @tracked name = 'one';
+    }
+
+    const sources: Record<string, string> = {
+      one: `# One`,
+      two: `# Two`,
+    };
+
+    const state = new State();
+    const context = {};
+
+    setOwner(context, this.owner);
+
+    const doc = compiledDoc(context, () => Promise.resolve(sources[state.name] ?? ''));
+
+    await render(
+      <template>
+        {{#if doc.prose}}
+          <doc.prose />
+        {{/if}}
+      </template>
+    );
+
+    assert.dom('h1').containsText('One');
+
+    const before = doc.prose;
+
+    state.name = 'two';
+
+    // While the new document is loading, the previous one is kept
+    // (no flash of emptiness)
+    assert.strictEqual(doc.prose, before);
+    assert.true(doc.isReady);
+
+    await settled();
+
+    assert.dom('h1').containsText('Two');
+    assert.notStrictEqual(doc.prose, before);
+  });
+
+  test('is pending until the load function returns something', async function (assert) {
+    class State {
+      @tracked ready = false;
+    }
+
+    const state = new State();
+    const context = {};
+
+    setOwner(context, this.owner);
+
+    const doc = compiledDoc(context, () => (state.ready ? `# Now ready` : undefined));
+
+    await render(
+      <template>
+        {{#if doc.isPending}}
+          <div data-pending>loading</div>
+        {{/if}}
+        {{#if doc.prose}}
+          <doc.prose />
+        {{/if}}
+      </template>
+    );
+
+    assert.dom('[data-pending]').exists();
+    assert.dom('h1').doesNotExist();
+
+    state.ready = true;
+    await settled();
+
+    assert.dom('h1').containsText('Now ready');
+    assert.dom('[data-pending]').doesNotExist();
+  });
+});

--- a/docs/util/compiled-doc.gjs.md
+++ b/docs/util/compiled-doc.gjs.md
@@ -1,0 +1,88 @@
+# `compiledDoc`
+
+Reactive load + compile + error state for a single document that you load yourself.
+
+This is the same machinery that [`selected`](/Runtime/util/selected.md) (and therefore `<Page />`) uses for rendering the current page — extracted so that documents fetched any other way (`fetch`, `import()`, an API, inline strings, etc.) get the same behavior:
+
+- markdown strings are compiled with your site-wide compiler configuration (remark / rehype plugins, top-level scope, extra modules)
+- while a re-load is happening, the previously rendered document is kept — no flash of emptiness
+- `settled()` in tests waits for the fetching and compiling to finish
+
+```gjs
+import Component from '@glimmer/component';
+import { compiledDoc } from 'kolay';
+
+export default class MyDocPage extends Component {
+  doc = compiledDoc(this, () =>
+    fetch(`/api/docs/${this.args.slug}.md`).then((response) => response.text())
+  );
+
+  <template>
+    {{#if this.doc.hasError}}
+      <div role="alert">{{this.doc.error}}</div>
+    {{else if this.doc.isPending}}
+      <div role="status">loading…</div>
+    {{/if}}
+
+    {{#if this.doc.prose}}
+      <this.doc.prose />
+    {{/if}}
+  </template>
+}
+```
+
+## The `load` function
+
+The second argument is a function that returns the document, in whichever of these shapes is convenient:
+
+- a string of markdown (compiled in the browser)
+- an already-compiled component
+- a module whose `default` export is either of the above (e.g.: the result of `import('...')`)
+- a `Promise` resolving to any of the above
+- `undefined`, while there is nothing to load yet (the state stays pending)
+
+The function is reactive: any tracked data read _synchronously_ (before the first `await`) will cause the document to re-load when that data changes — e.g. reading `this.args.slug` in the example above re-fetches when the slug changes.
+
+## Lifetime and owner
+
+The first argument is the context the state is linked to: destroying the context tears the state down, and the context's owner is used for compiling (so the context must have an owner — a component, route, service, or an object that had `setOwner` called on it).
+
+## Example
+
+```gjs live preview no-shadow
+import Component from '@glimmer/component';
+import { compiledDoc } from 'kolay';
+
+// stand-in for a fetch() to somewhere
+const request = () =>
+  Promise.resolve(`Hello from **somewhere else**
+
+\`\`\`hbs live
+<p>even live codefences work</p>
+\`\`\`
+`);
+
+export default class Demo extends Component {
+  doc = compiledDoc(this, request);
+
+  <template>
+    <fieldset>
+      <legend>Demo</legend>
+
+      {{#if this.doc.isPending}}
+        loading…
+      {{/if}}
+
+      {{#if this.doc.prose}}
+        <this.doc.prose />
+      {{/if}}
+    </fieldset>
+  </template>
+}
+```
+
+If you already have the markdown synchronously and don't need the keep-latest behavior, the smaller [`Compiled`](/usage/rendering-pages.md) helper may be all you need.
+
+## API Reference
+
+<APIDocs @module="declarations/browser" @name="compiledDoc" @package="kolay" />

--- a/docs/util/compiled-doc.gjs.md
+++ b/docs/util/compiled-doc.gjs.md
@@ -13,7 +13,7 @@ import Component from '@glimmer/component';
 import { compiledDoc } from 'kolay';
 
 export default class MyDocPage extends Component {
-  doc = compiledDoc(this, () =>
+  doc = compiledDoc(() =>
     fetch(`/api/docs/${this.args.slug}.md`).then((response) => response.text())
   );
 
@@ -31,9 +31,11 @@ export default class MyDocPage extends Component {
 }
 ```
 
+The compiler is configured app-wide via [`setupKolay`](/usage/setup.md) (or `setupCompiler` from `ember-repl/test-support` in tests), so that must have run before a document loads — there is nothing to pass, link, or destroy per call site.
+
 ## The `load` function
 
-The second argument is a function that returns the document, in whichever of these shapes is convenient:
+The argument is a function that returns the document, in whichever of these shapes is convenient:
 
 - a string of markdown (compiled in the browser)
 - an already-compiled component
@@ -43,42 +45,34 @@ The second argument is a function that returns the document, in whichever of the
 
 The function is reactive: any tracked data read _synchronously_ (before the first `await`) will cause the document to re-load when that data changes — e.g. reading `this.args.slug` in the example above re-fetches when the slug changes.
 
-## Lifetime and owner
-
-The first argument is the context the state is linked to: destroying the context tears the state down, and the context's owner is used for compiling (so the context must have an owner — a component, route, service, or an object that had `setOwner` called on it).
-
 ## Example
 
 ```gjs live preview no-shadow
-import Component from '@glimmer/component';
 import { compiledDoc } from 'kolay';
 
 // stand-in for a fetch() to somewhere
-const request = () =>
+const doc = compiledDoc(() =>
   Promise.resolve(`Hello from **somewhere else**
 
 \`\`\`hbs live
 <p>even live codefences work</p>
 \`\`\`
-`);
+`)
+);
 
-export default class Demo extends Component {
-  doc = compiledDoc(this, request);
+<template>
+  <fieldset>
+    <legend>Demo</legend>
 
-  <template>
-    <fieldset>
-      <legend>Demo</legend>
+    {{#if doc.isPending}}
+      loading…
+    {{/if}}
 
-      {{#if this.doc.isPending}}
-        loading…
-      {{/if}}
-
-      {{#if this.doc.prose}}
-        <this.doc.prose />
-      {{/if}}
-    </fieldset>
-  </template>
-}
+    {{#if doc.prose}}
+      <doc.prose />
+    {{/if}}
+  </fieldset>
+</template>
 ```
 
 If you already have the markdown synchronously and don't need the keep-latest behavior, the smaller [`Compiled`](/usage/rendering-pages.md) helper may be all you need.

--- a/docs/util/selected.gjs.md
+++ b/docs/util/selected.gjs.md
@@ -1,8 +1,8 @@
 # `selected`
 
-Access the reactive state for the currently selected/visible page. This store manages loading the compiled page content, resolving it from the URL, and providing the rendered component.
+Access the reactive state for the currently selected/visible page. This store resolves the current page from the URL, loads and compiles its document, and provides the rendered component.
 
-This is primarily used internally by the `<Page />` component, but is available for advanced use cases where you need direct access to the current page's compilation state.
+This is what the `<Page />` component uses internally, and it is available directly for when you want to render the current page yourself.
 
 ```js
 import { selected } from 'kolay';
@@ -10,13 +10,46 @@ import { selected } from 'kolay';
 // inside a class with an owner
 const current = selected(this);
 
-current.page;           // the current Page object
-current.component;      // the compiled component (if ready)
-current.isLoading;      // whether the page is still loading/compiling
-current.error;          // any error that occurred during compilation
+current.prose;     // the rendered document (a component), if ready
+current.isReady;   // finished loading + compiling?
+current.isPending; // still loading / compiling?
+current.hasError;  // did resolving the page, loading, or compiling fail?
+current.error;     // a human-readable error message ('' when there is none)
+current.hasProse;  // Boolean(current.prose)
+current.doc;       // the underlying document state, a `CompiledDoc`
 ```
+
+## Rendering the current page yourself
+
+`<Page />` is a thin wrapper around this store. If its three blocks don't give you enough control, you can use `selected` directly:
+
+```gjs
+import Component from '@glimmer/component';
+import { selected } from 'kolay';
+
+export default class MyPage extends Component {
+  get current() {
+    return selected(this);
+  }
+
+  <template>
+    {{#if this.current.hasError}}
+      <div role="alert">{{this.current.error}}</div>
+    {{else if this.current.isPending}}
+      <div role="status">loading…</div>
+    {{/if}}
+
+    {{#if this.current.prose}}
+      <this.current.prose />
+    {{/if}}
+  </template>
+}
+```
+
+Note that `prose` can be present at the same time as `isPending` or `hasError`: while a new page is loading (or after it errored), the previously rendered page is kept, so navigation doesn't flash an empty screen.
+
+To render a document that is _not_ the current page (something you fetched yourself), see [`compiledDoc`](/Runtime/util/compiled-doc.md).
 
 ## API Reference
 
 <APIDocs @module="declarations/browser" @name="selected" @package="kolay" />
-

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -12,6 +12,7 @@ export {
 // Required to use Kolay
 export { addRoutes, handlePotentialIndexVisit } from './router.ts';
 export { typedocLoader } from './services/api-docs.ts';
+export { CompiledDoc, compiledDoc } from './services/compiled-doc.ts';
 export { Compiled } from './services/compiler/reactive.ts';
 export { docsManager } from './services/docs.ts';
 export { selected } from './services/selected.ts';
@@ -22,4 +23,5 @@ export { getIndexPage, isCollection, isIndex } from './utils.ts';
 
 // Types
 export type { Collection, Manifest, Page } from '../types.ts';
+export type { DocModule, DocSource } from './services/compiled-doc.ts';
 export type { SetupOptions } from './services/docs.ts';

--- a/src/browser/services/compiled-doc.ts
+++ b/src/browser/services/compiled-doc.ts
@@ -1,17 +1,15 @@
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import { assert } from '@ember/debug';
-import { getOwner } from '@ember/owner';
 import { waitForPromise } from '@ember/test-waiters';
 
-import { use } from 'ember-resources';
 import { getPromiseState } from 'reactiveweb/get-promise-state';
-import { keepLatest } from 'reactiveweb/keep-latest';
-import { link } from 'reactiveweb/link';
 
 import { compileText } from './compiler/reactive.ts';
 import { extractErrorMessage } from './extract-error-message.ts';
+import { getKey } from './lazy-load.ts';
 
 import type { ComponentLike } from '@glint/template';
+import type { State } from 'reactiveweb/get-promise-state';
 
 /**
  * A module containing a document, e.g. the result of `import('/some-doc.md?raw')`
@@ -35,9 +33,8 @@ export type DocSource = string | ComponentLike | DocModule;
  * any other way (`fetch`, `import()`, inline strings, etc.) get the same
  * loading / error / anti-flicker behavior.
  *
- * The instance's lifetime is linked to the passed context, and the owner is
- * pulled from that context (the compiler is per-owner, configured via
- * `setupKolay` (or `setupCompiler` in tests)).
+ * The compiler is configured via `setupKolay` (or `setupCompiler` in
+ * tests), so one of those must have run before a document loads.
  *
  * The `load` function is reactive: any tracked data read synchronously
  * (before the first `await`) will cause the document to be re-loaded when
@@ -49,7 +46,7 @@ export type DocSource = string | ComponentLike | DocModule;
  * import { compiledDoc } from 'kolay';
  *
  * export default class MyPage extends Component {
- *   doc = compiledDoc(this, () =>
+ *   doc = compiledDoc(() =>
  *     fetch(`/my-docs/${this.args.name}.md`).then((response) => response.text())
  *   );
  *
@@ -65,11 +62,8 @@ export type DocSource = string | ComponentLike | DocModule;
  * }
  * ```
  */
-export function compiledDoc(
-  context: object,
-  load: () => DocSource | Promise<DocSource> | undefined
-): CompiledDoc {
-  return link(new CompiledDoc(load), context);
+export function compiledDoc(load: () => DocSource | Promise<DocSource> | undefined): CompiledDoc {
+  return new CompiledDoc(load);
 }
 
 function isDocModule(source: DocSource): source is DocModule {
@@ -99,13 +93,11 @@ export class CompiledDoc {
 
     if (source === undefined) return;
 
-    const owner = getOwner(this);
+    // The compiler is per-owner; documents at an URL can't change, so any
+    // live owner that setupKolay registered will do.
+    const owner = getKey(this);
 
-    assert(
-      `Owner is missing. compiledDoc must be linked to a context that has an owner ` +
-        `(e.g.: a component, or an object created with an owner).`,
-      owner
-    );
+    assert(`[Bug] Owner is missing`, owner);
 
     const resolve = async (): Promise<ComponentLike | undefined> => {
       const resolved = await source;
@@ -132,17 +124,28 @@ export class CompiledDoc {
     return getValue(this.#stateCache);
   }
 
+  #previousState: State<ComponentLike | undefined> | undefined;
+
   /*********************************************************************
    * This is a pattern to help reduce flashes of content during
    * the intermediate states of the above request fetchers.
    * When a new request starts, we'll hold on the old value for as long as
    * we can, and only swap out the old data when the new data is done loading.
    *
+   * (reading `isLoading` entangles this getter with the request's
+   *  progress, so consumers re-render when loading finishes)
    ********************************************************************/
-  @use latest = keepLatest({
-    value: () => this.#state,
-    when: () => Boolean(this.#state?.isLoading),
-  });
+  get latest(): State<ComponentLike | undefined> | undefined {
+    const current = this.#state;
+
+    if (current?.isLoading) {
+      return this.#previousState ?? current;
+    }
+
+    this.#previousState = current;
+
+    return current;
+  }
 
   /**
    * The rendered document, ready for invoking.

--- a/src/browser/services/compiled-doc.ts
+++ b/src/browser/services/compiled-doc.ts
@@ -1,0 +1,186 @@
+import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import { assert } from '@ember/debug';
+import { getOwner } from '@ember/owner';
+import { waitForPromise } from '@ember/test-waiters';
+
+import { use } from 'ember-resources';
+import { getPromiseState } from 'reactiveweb/get-promise-state';
+import { keepLatest } from 'reactiveweb/keep-latest';
+import { link } from 'reactiveweb/link';
+
+import { compileText } from './compiler/reactive.ts';
+import { extractErrorMessage } from './extract-error-message.ts';
+
+import type { ComponentLike } from '@glint/template';
+
+/**
+ * A module containing a document, e.g. the result of `import('/some-doc.md?raw')`
+ * or of a compiled `.gjs.md` module.
+ */
+export type DocModule = { default: string | ComponentLike };
+
+/**
+ * What a document may be loaded as:
+ * - a string of markdown (compiled in the browser)
+ * - an already-compiled component (e.g.: the module of a build-time-compiled `.gjs.md` file)
+ * - a module whose default export is either of the above
+ */
+export type DocSource = string | ComponentLike | DocModule;
+
+/**
+ * Reactive state for rendering a single document that you load yourself.
+ *
+ * This is the same machinery that the `<Page />` component (via `selected`)
+ * uses for rendering the current page — extracted so that documents fetched
+ * any other way (`fetch`, `import()`, inline strings, etc.) get the same
+ * loading / error / anti-flicker behavior.
+ *
+ * The instance's lifetime is linked to the passed context, and the owner is
+ * pulled from that context (the compiler is per-owner, configured via
+ * `setupKolay` (or `setupCompiler` in tests)).
+ *
+ * The `load` function is reactive: any tracked data read synchronously
+ * (before the first `await`) will cause the document to be re-loaded when
+ * that data changes. While re-loading, the previously rendered document is
+ * kept, avoiding a flash of emptiness.
+ *
+ * ```gjs
+ * import Component from '@glimmer/component';
+ * import { compiledDoc } from 'kolay';
+ *
+ * export default class MyPage extends Component {
+ *   doc = compiledDoc(this, () =>
+ *     fetch(`/my-docs/${this.args.name}.md`).then((response) => response.text())
+ *   );
+ *
+ *   <template>
+ *     {{#if this.doc.isPending}}
+ *       loading…
+ *     {{else if this.doc.hasError}}
+ *       {{this.doc.error}}
+ *     {{else if this.doc.prose}}
+ *       <this.doc.prose />
+ *     {{/if}}
+ *   </template>
+ * }
+ * ```
+ */
+export function compiledDoc(
+  context: object,
+  load: () => DocSource | Promise<DocSource> | undefined
+): CompiledDoc {
+  return link(new CompiledDoc(load), context);
+}
+
+function isDocModule(source: DocSource): source is DocModule {
+  return typeof source === 'object' && source !== null && 'default' in source;
+}
+
+export class CompiledDoc {
+  #load: () => DocSource | Promise<DocSource> | undefined;
+
+  constructor(load: () => DocSource | Promise<DocSource> | undefined) {
+    this.#load = load;
+  }
+
+  /**
+   * With .gjs.md and .gts.md documents, we have only one promise to deal with.
+   * With .md documents, we have two promises.
+   *
+   * .gjs.md / .gts.md:
+   *  1. the request to get the module
+   *
+   * .md
+   *  1. the request to get the module
+   *  2. compile
+   */
+  #stateCache = createCache(() => {
+    const source = this.#load();
+
+    if (source === undefined) return;
+
+    const owner = getOwner(this);
+
+    assert(
+      `Owner is missing. compiledDoc must be linked to a context that has an owner ` +
+        `(e.g.: a component, or an object created with an owner).`,
+      owner
+    );
+
+    const resolve = async (): Promise<ComponentLike | undefined> => {
+      const resolved = await source;
+      const doc = isDocModule(resolved) ? resolved.default : resolved;
+
+      if (typeof doc === 'string') {
+        const state = compileText(owner, doc);
+
+        return state.promise;
+      }
+
+      return doc;
+    };
+
+    return getPromiseState(() =>
+      // Holds `settled()` (visit/click in tests) open for the fetch and
+      // compile, so tests never see a partially-rendered page. No-op in
+      // production builds.
+      waitForPromise(resolve())
+    );
+  });
+
+  get #state() {
+    return getValue(this.#stateCache);
+  }
+
+  /*********************************************************************
+   * This is a pattern to help reduce flashes of content during
+   * the intermediate states of the above request fetchers.
+   * When a new request starts, we'll hold on the old value for as long as
+   * we can, and only swap out the old data when the new data is done loading.
+   *
+   ********************************************************************/
+  @use latest = keepLatest({
+    value: () => this.#state,
+    when: () => Boolean(this.#state?.isLoading),
+  });
+
+  /**
+   * The rendered document, ready for invoking.
+   * While a new document is loading, this remains the previous document.
+   */
+  get prose(): ComponentLike | undefined {
+    if (this.hasError) {
+      return;
+    }
+
+    return this.latest?.resolved;
+  }
+
+  get isReady(): boolean {
+    return Boolean(this.latest?.resolved);
+  }
+
+  get isPending(): boolean {
+    return !this.isReady;
+  }
+
+  /**
+   * The raw error from loading or compiling, if there was one.
+   * See `error` for a human-readable message.
+   */
+  get rawError(): unknown {
+    return this.latest?.error;
+  }
+
+  /**
+   * A human-readable message extracted from `rawError`
+   * (may be `''` when the raw error has no extractable message).
+   */
+  get error(): string {
+    return extractErrorMessage(this.rawError);
+  }
+
+  get hasError(): boolean {
+    return Boolean(this.rawError);
+  }
+}

--- a/src/browser/services/selected.ts
+++ b/src/browser/services/selected.ts
@@ -31,28 +31,21 @@ class Selected {
     return docsManager(this);
   }
 
-  #doc: CompiledDoc | undefined;
-
   /**
    * The load / compile / error state for the current page's document.
-   *
-   * (Lazily created, because while this store is being constructed,
-   *  it does not have an owner yet)
    */
-  get doc(): CompiledDoc {
-    return (this.#doc ??= compiledDoc(this, () => {
-      const path = this.#matchOrFirstPagePath;
+  doc: CompiledDoc = compiledDoc(() => {
+    const path = this.#matchOrFirstPagePath;
 
-      if (!path) return;
+    if (!path) return;
 
-      /**
-       * NOTE: we support paths with and withouth the '.md' on the URL
-       */
-      const fn = this.compiledDocs[path] ?? this.compiledDocs[path + '.md'];
+    /**
+     * NOTE: we support paths with and withouth the '.md' on the URL
+     */
+    const fn = this.compiledDocs[path] ?? this.compiledDocs[path + '.md'];
 
-      return fn?.();
-    }));
-  }
+    return fn?.();
+  });
 
   get prose() {
     if (this.error) {

--- a/src/browser/services/selected.ts
+++ b/src/browser/services/selected.ts
@@ -1,21 +1,15 @@
 import { cached } from '@glimmer/tracking';
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
-import { assert } from '@ember/debug';
-import { getOwner } from '@ember/owner';
 import { service } from '@ember/service';
-import { waitForPromise } from '@ember/test-waiters';
 
 import { createStore } from 'ember-primitives/store';
-import { use } from 'ember-resources';
-import { getPromiseState } from 'reactiveweb/get-promise-state';
-import { keepLatest } from 'reactiveweb/keep-latest';
 
-import { compileText } from './compiler/reactive.ts';
+import { compiledDoc } from './compiled-doc.ts';
 import { docsManager } from './docs.ts';
-import { extractErrorMessage } from './extract-error-message.ts';
 import { getKey } from './lazy-load.ts';
 
 import type { Page } from '../../types.ts';
+import type { CompiledDoc } from './compiled-doc.ts';
 import type RouterService from '@ember/routing/router-service';
 import type { ComponentLike } from '@glint/template';
 
@@ -28,57 +22,6 @@ export function selected(context: unknown) {
 type File = { default: string | ComponentLike };
 type Loader = () => Promise<File>;
 
-/**
- * With .gjs.md and .gts.md documents, we have only one promise to deal with.
- * With .md documents, we have two promises.
- *
- * .gjs.md / .gts.md:
- *  1. the request to get the module
- *
- * .md
- *  1. the request to get the module
- *  2. compile
- */
-function loaderFor(selected: Selected, path: string | undefined) {
-  if (!path) return;
-
-  const docs = selected.compiledDocs;
-  const owner = getOwner(selected);
-
-  /**
-   * NOTE: we support paths with and withouth the '.md' on the URL
-   */
-  const fn = docs[path] ?? docs[path + '.md'];
-
-  async function load(): Promise<ComponentLike | undefined> {
-    assert(`[Bug] Owner is missing`, owner);
-    assert(`Invalid path: ${path}. No loader found.`, fn);
-
-    const module = await fn();
-
-    if (typeof module.default === 'string') {
-      const state = compileText(owner, module.default);
-
-      return state.promise;
-    }
-
-    return module.default;
-  }
-
-  async function wrapper(): Promise<ComponentLike | undefined> {
-    if (!fn) return;
-
-    // Holds `settled()` (visit/click in tests) open for the module fetch and
-    // compile, so tests never see a partially-rendered page. No-op in
-    // production builds.
-    return waitForPromise(load());
-  }
-
-  const wrapped = getPromiseState(wrapper);
-
-  return wrapped;
-}
-
 class Selected {
   @service declare router: RouterService;
 
@@ -88,33 +31,39 @@ class Selected {
     return docsManager(this);
   }
 
-  @cached
-  get loader() {
-    return loaderFor(this, this.#matchOrFirstPagePath);
-  }
+  #doc: CompiledDoc | undefined;
 
-  /*********************************************************************
-   * This is a pattern to help reduce flashes of content during
-   * the intermediate states of the above request fetchers.
-   * When a new request starts, we'll hold on the old value for as long as
-   * we can, and only swap out the old data when the new data is done loading.
+  /**
+   * The load / compile / error state for the current page's document.
    *
-   ********************************************************************/
-  @use activeCompiled = keepLatest({
-    value: () => this.loader,
-    when: () => Boolean(this.loader?.isLoading),
-  });
+   * (Lazily created, because while this store is being constructed,
+   *  it does not have an owner yet)
+   */
+  get doc(): CompiledDoc {
+    return (this.#doc ??= compiledDoc(this, () => {
+      const path = this.#matchOrFirstPagePath;
+
+      if (!path) return;
+
+      /**
+       * NOTE: we support paths with and withouth the '.md' on the URL
+       */
+      const fn = this.compiledDocs[path] ?? this.compiledDocs[path + '.md'];
+
+      return fn?.();
+    }));
+  }
 
   get prose() {
     if (this.error) {
       return;
     }
 
-    return this.activeCompiled?.resolved;
+    return this.doc.prose;
   }
 
   get isReady() {
-    return Boolean(this.activeCompiled?.resolved);
+    return this.doc.isReady;
   }
 
   get isPending() {
@@ -126,7 +75,7 @@ class Selected {
       return Boolean(this.error);
     }
 
-    return Boolean(this.activeCompiled?.error);
+    return this.doc.hasError;
   }
 
   @cached
@@ -139,8 +88,7 @@ class Selected {
       return message;
     }
 
-    const rawError = this.activeCompiled?.error;
-    const error = extractErrorMessage(rawError);
+    const error = this.doc.error;
 
     if (!error) return '';
 


### PR DESCRIPTION
Part of #323 (the "decouple page rendering / data loading" portion — plugin-API suggestions from that issue are intentionally not addressed here).

## What

Extracts the load → compile → promise-state → keep-latest machinery out of the `selected` store into a public utility, and documents how to render docs yourself — both the current page (via `selected`) and documents you fetch some other way.

### `compiledDoc(load)` (new export)

The exact machinery `<Page />` uses for the current page, now usable for any document:

```gjs
import Component from '@glimmer/component';
import { compiledDoc } from 'kolay';

export default class MyDocPage extends Component {
  doc = compiledDoc(() =>
    fetch(`/api/docs/${this.args.slug}.md`).then((response) => response.text())
  );

  <template>
    {{#if this.doc.prose}}<this.doc.prose />{{/if}}
  </template>
}
```

- accepts markdown strings, compiled components, `{ default }` modules, promises of those, or `undefined` (pending)
- markdown compiles with the site-wide compiler config (remark/rehype plugins, scope, modules)
- keep-latest caching: while a re-load happens, the previous document is kept (no flash)
- `waitForPromise` integration, so `settled()` in consumers' tests waits for fetch + compile
- reactive: tracked data read synchronously in `load` re-loads the doc on change

No context/`this` argument: `CompiledDoc` is plain state — no services, no teardown, no owner linking. The compile owner comes from the `setupKolay`-registered owner registry at load time, and the keep-latest hold is a plain previous-state getter rather than a resource.

The `selected` store now delegates to a `CompiledDoc` (exposed as `selected(this).doc`); its public API (`prose`, `isReady`, `isPending`, `hasError`, `error`, `hasProse`) is unchanged.

### Docs

- new `Runtime/util/compiled-doc` page with a live demo (including a nested live codefence)
- rewrote `Runtime/util/selected` — it documented properties that don't exist (`page`, `component`, `isLoading`) — now shows the real API and how to render the current page without `<Page />`
- `usage/rendering-pages` gained "Rendering the current page yourself" and "Rendering documents you fetch yourself" sections

## Testing

- 5 new rendering tests for `compiledDoc` (string, async, module-with-component, keep-latest across reloads, pending-until-loadable)
- 2 new acceptance tests visiting the new/rewritten docs pages (the all-links test is skipped in CI, so these pin the pages down)
- docs-app suite, both test-apps, vitest, and repo lint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
