### PR TITLE
Rename typedoc() to apiDocs(); page json componentName to title

### DIFF
--- a/docs-app/src/templates/application.gts
+++ b/docs-app/src/templates/application.gts
@@ -153,10 +153,9 @@ export default Route(
 );
 
 export function nameFor(x: Page) {
-  // We defined componentName via json file
-
-  if ('componentName' in x) {
-    return `${x.componentName}`;
+  // The link text, defined via a json file next to the page
+  if (x.title) {
+    return x.title;
   }
 
   if (x.path.includes('/components/')) {

--- a/docs-app/src/templates/authoring/code-fences.gjs.md
+++ b/docs-app/src/templates/authoring/code-fences.gjs.md
@@ -53,7 +53,7 @@ Live fences aren't limited to Ember. These are the fence languages repl-sdk can 
 Where they work differs by compile mode:
 
 - In **`.gjs.md`** files (build-time compiled), live fences may be `gjs` or `hbs`. They compile to real components during the build, so they get full build-time error checking.
-- In **`.md`** files (runtime compiled) — and in codefences inside your JSDoc, rendered by the [TypeDoc components](/TypeDoc/plugin/typedoc.md) — the browser compiler is used, and all of the targets above are available. Non-Ember targets fetch their dependencies (react, svelte, vue, mermaid, …) on demand, so pages only pay for what they render.
+- In **`.md`** files (runtime compiled) — and in codefences inside your JSDoc, rendered by the [TypeDoc components](/TypeDoc/plugin/api-docs.md) — the browser compiler is used, and all of the targets above are available. Non-Ember targets fetch their dependencies (react, svelte, vue, mermaid, …) on demand, so pages only pay for what they render.
 
 An `hbs` fence is implicitly wrapped in a template, so it's the quickest way to demo component invocations:
 
@@ -70,7 +70,7 @@ Live fences can `import` from anything your app can import from. To use componen
 - for `.gjs.md` files: the [`scope` option of `docs()`](/development/configuring-docs.md) — a string of import statements prepended to every file at build time
 - for `.md` files: the `topLevelScope` and `modules` options of `setupKolay()` — values and importable modules provided to the runtime compiler
 
-By default, the runtime scope already provides `<Shadowed>` (from `ember-primitives`) for style isolation, and the [TypeDoc components](/TypeDoc/plugin/typedoc.md): `<APIDocs>`, `<ComponentSignature>`, `<ModifierSignature>`, `<HelperSignature>`, and `<CommentQuery>`.
+By default, the runtime scope already provides `<Shadowed>` (from `ember-primitives`) for style isolation, and the [TypeDoc components](/TypeDoc/plugin/api-docs.md): `<APIDocs>`, `<ComponentSignature>`, `<ModifierSignature>`, `<HelperSignature>`, and `<CommentQuery>`.
 
 ## Escaping
 

--- a/docs-app/src/templates/development/configuring-api-docs.json
+++ b/docs-app/src/templates/development/configuring-api-docs.json
@@ -1,0 +1,4 @@
+{
+  "href": "/TypeDoc/plugin/api-docs.md",
+  "title": "Configuring apiDocs(...)"
+}

--- a/docs-app/src/templates/development/configuring-docs.gjs.md
+++ b/docs-app/src/templates/development/configuring-docs.gjs.md
@@ -2,12 +2,12 @@
 
 Kolay requires some build-time static analysis to function.
 
-`docs(...)` is the only required plugin. This generates the navigation and information about how Kolay's runtime code will fetch the markdown documents deployed with the app's static assets. To also generate api docs from your libraries' type declarations, add the [`typedoc(...)`][plugin-typedoc] plugin.
+`docs(...)` is the only required plugin. This generates the navigation and information about how Kolay's runtime code will fetch the markdown documents deployed with the app's static assets. To also generate api docs from your libraries' type declarations, add the [`apiDocs(...)`][plugin-typedoc] plugin.
 
 > **Note:** `docs` + `typedoc` used to be one combined plugin, `kolay(...)`. That export still works (it composes the two), but is deprecated.
 
 [plugin-docs]: /development/configuring-docs.md
-[plugin-typedoc]: /TypeDoc/plugin/typedoc.md
+[plugin-typedoc]: /TypeDoc/plugin/api-docs.md
 [ui-signature]: /TypeDoc/components/component-signature.md
 [ui-apiDocs]: /TypeDoc/components/api-docs.md
 

--- a/docs-app/src/templates/development/configuring-docs.json
+++ b/docs-app/src/templates/development/configuring-docs.json
@@ -1,1 +1,1 @@
-{ "componentName": "Configuring docs()" }
+{ "title": "Configuring docs()" }

--- a/docs-app/src/templates/development/configuring-typedoc.json
+++ b/docs-app/src/templates/development/configuring-typedoc.json
@@ -1,4 +1,0 @@
-{
-  "href": "/TypeDoc/plugin/typedoc.md",
-  "componentName": "Configuring typedoc(...)"
-}

--- a/docs-app/src/templates/development/meta.json
+++ b/docs-app/src/templates/development/meta.json
@@ -5,6 +5,6 @@
     "renaming-pages",
     "testing",
     "configuring-docs",
-    "configuring-typedoc"
+    "configuring-api-docs"
   ]
 }

--- a/docs-app/src/templates/development/renaming-pages.gjs.md
+++ b/docs-app/src/templates/development/renaming-pages.gjs.md
@@ -9,19 +9,19 @@ docs/
     selected.json
 ```
 
-Any keys in that file are merged into the page's manifest entry. The convention for display names is `componentName`:
+Any keys in that file are merged into the page's manifest entry. The link text is `title`:
 
 ```jsonc
 // selected.json
-{ "componentName": "selected(...)" }
+{ "title": "selected(...)" }
 ```
 
 Your nav decides how to use it — this site's `nameFor` helper, passed to [`<PageNav />`](/Runtime/navigation/page-nav.md), looks like:
 
 ```js
 export function nameFor(page) {
-  if ("componentName" in page) {
-    return `${page.componentName}`;
+  if (page.title) {
+    return page.title;
   }
 
   return sentenceCase(page.name);
@@ -37,13 +37,13 @@ That is how the [Runtime](/Runtime/rendering/page.md) and [TypeDoc](/TypeDoc/com
 A json file with an `href` — and no markdown file of its own — becomes a nav entry that is just a link. It participates in naming and ordering like any page, but points wherever the `href` says, e.g. a page in another group:
 
 ```jsonc
-// development/configuring-typedoc.json
+// development/configuring-api-docs.json
 {
-  "href": "/TypeDoc/plugin/typedoc.md",
-  "componentName": "Configuring typedoc(...)",
+  "href": "/TypeDoc/plugin/api-docs.md",
+  "title": "Configuring apiDocs(...)",
 }
 ```
 
-That file produces the "Configuring typedoc(...)" entry in this very section — it links over to the TypeDoc group.
+That file produces the "Configuring apiDocs(...)" entry in this very section — it links over to the TypeDoc group.
 
 The `href` is written app-relative (as if the app were deployed at `/`); the app's `rootURL` is applied automatically, the same as for authored links.

--- a/docs-app/src/templates/install/index.gjs.md
+++ b/docs-app/src/templates/install/index.gjs.md
@@ -77,7 +77,7 @@ There are two areas of configuration needed: buildtime, and runtime[^runtime-opt
 import `kolay/vite`
 
 ```js
-import { docs, typedoc } from "kolay/vite";
+import { docs, apiDocs } from "kolay/vite";
 
 export default defineConfig(({ mode }) => {
   return {
@@ -87,7 +87,7 @@ export default defineConfig(({ mode }) => {
         src: "public/docs",
       }),
       // Optional: generate API Docs for packages listed here
-      typedoc(["kolay"]),
+      apiDocs(["kolay"]),
       // ...
     ],
   };
@@ -110,7 +110,7 @@ docs({
 }),
 // Generate API docs from JSDoc
 // NOTE: these must all be declared in your projects package.json
-typedoc(['kolay', 'ember-primitives', 'ember-resources']),
+apiDocs(['kolay', 'ember-primitives', 'ember-resources']),
 ```
 
 This is useful for monorepos where they may be scaling to large teams and many packages could end up being added quickly. In a traditionally compiled app, this may cause build times to slow down over time. Since many docs' sites are deployed continuously, that is wasted time and money spent on building things that may not be looked at all that often (we all wish folks looked at docs more!).

--- a/docs-app/tests/docs-app/home-nav-test.gts
+++ b/docs-app/tests/docs-app/home-nav-test.gts
@@ -63,12 +63,12 @@ module('Home docs navigation', function (hooks) {
     assert.dom('img[src="./kolay-logo.svg"]').exists({ count: 1 }, 'relative image');
   });
 
-  test('the typedoc entry is a nav-only link into the TypeDoc group', async function (assert) {
+  test('the apiDocs entry is a nav-only link into the TypeDoc group', async function (assert) {
     await visit('/development/rendering-pages');
 
     assert
-      .dom(`aside nav a[href="/TypeDoc/plugin/typedoc.md"]`)
-      .containsText('Configuring typedoc(...)');
+      .dom(`aside nav a[href="/TypeDoc/plugin/api-docs.md"]`)
+      .containsText('Configuring apiDocs(...)');
 
     assert.dom('aside nav').containsText('Configuring docs()');
   });

--- a/docs-app/vite.config.js
+++ b/docs-app/vite.config.js
@@ -2,7 +2,7 @@ import { ember, extensions } from '@embroider/vite';
 
 import { babel } from '@rollup/plugin-babel';
 import rehypeShiki from '@shikijs/rehype';
-import { docs, typedoc } from 'kolay/vite';
+import { apiDocs, docs } from 'kolay/vite';
 import info from 'unplugin-info/vite';
 import { defineConfig } from 'vite';
 import inspect from 'vite-plugin-inspect';
@@ -44,7 +44,7 @@ export default defineConfig(async ({ mode }) => {
         import { InViewport } from 'ember-primitives/viewport';
         `,
       }),
-      typedoc(['kolay', 'ember-primitives', 'ember-resources']),
+      apiDocs(['kolay', 'ember-primitives', 'ember-resources']),
       babel({
         babelHelpers: 'runtime',
         extensions,

--- a/docs-typedoc/components/api-docs.json
+++ b/docs-typedoc/components/api-docs.json
@@ -1,1 +1,1 @@
-{ "componentName": "<APIDocs />" }
+{ "title": "<APIDocs />" }

--- a/docs-typedoc/plugin/api-docs.gjs.md
+++ b/docs-typedoc/plugin/api-docs.gjs.md
@@ -1,4 +1,4 @@
-# `typedoc(...)`
+# `apiDocs(...)`
 
 Generates api docs (typedoc JSON) from your libraries' type declarations, and teaches the runtime how to fetch them. Rendering these api docs uses the [Signature Components][ui-signature] or [`APIDocs`][ui-apiDocs] components.
 
@@ -12,7 +12,7 @@ Usage with Vite:
 
 ```js
 // vite.config.js
-import { docs, typedoc } from "kolay/vite";
+import { docs, apiDocs } from "kolay/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
@@ -21,7 +21,7 @@ export default defineConfig({
       /* ... */
     }),
     // Package names must be installed; relative paths must exist.
-    typedoc(["my-library", "./packages/my-other-library"]),
+    apiDocs(["my-library", "./packages/my-other-library"]),
   ],
 });
 ```

--- a/docs-typedoc/plugin/api-docs.json
+++ b/docs-typedoc/plugin/api-docs.json
@@ -1,0 +1,1 @@
+{ "title": "apiDocs(...)" }

--- a/docs/demo-support/logs.json
+++ b/docs/demo-support/logs.json
@@ -1,1 +1,1 @@
-{ "componentName": "<Logs />" }
+{ "title": "<Logs />" }

--- a/docs/navigation/group-nav.json
+++ b/docs/navigation/group-nav.json
@@ -1,1 +1,1 @@
-{ "componentName": "<GroupNav />" }
+{ "title": "<GroupNav />" }

--- a/docs/navigation/handle-potential-index-visit.json
+++ b/docs/navigation/handle-potential-index-visit.json
@@ -1,1 +1,1 @@
-{ "componentName": "handlePotentialIndexVisit(...)" }
+{ "title": "handlePotentialIndexVisit(...)" }

--- a/docs/navigation/is-active.json
+++ b/docs/navigation/is-active.json
@@ -1,1 +1,1 @@
-{ "componentName": "isActive(...)" }
+{ "title": "isActive(...)" }

--- a/docs/navigation/page-nav.json
+++ b/docs/navigation/page-nav.json
@@ -1,1 +1,1 @@
-{ "componentName": "<PageNav />" }
+{ "title": "<PageNav />" }

--- a/docs/rendering/compiled-doc.json
+++ b/docs/rendering/compiled-doc.json
@@ -1,1 +1,1 @@
-{ "componentName": "compiledDoc(...)" }
+{ "title": "compiledDoc(...)" }

--- a/docs/rendering/compiled.json
+++ b/docs/rendering/compiled.json
@@ -1,1 +1,1 @@
-{ "componentName": "Compiled(...)" }
+{ "title": "Compiled(...)" }

--- a/docs/rendering/page.json
+++ b/docs/rendering/page.json
@@ -1,1 +1,1 @@
-{ "componentName": "<Page>" }
+{ "title": "<Page>" }

--- a/docs/utilities/docs-manager.json
+++ b/docs/utilities/docs-manager.json
@@ -1,1 +1,1 @@
-{ "componentName": "docsManager(...)" }
+{ "title": "docsManager(...)" }

--- a/docs/utilities/selected.json
+++ b/docs/utilities/selected.json
@@ -1,1 +1,1 @@
-{ "componentName": "selected(...)" }
+{ "title": "selected(...)" }

--- a/src/build/plugins/api-docs/index.js
+++ b/src/build/plugins/api-docs/index.js
@@ -29,7 +29,7 @@ const SECRET_INTERNAL_IMPORT = 'kolay/api-docs:virtual';
  * @type {(options: import('./types.ts').APIDocsOptions) => import('unplugin').UnpluginOptions}
  */
 export const apiDocs = (options) => {
-  const name = 'kolay:typedoc';
+  const name = 'kolay:apidocs';
 
   /**
    * @param {string} pkgName - a package name or relative path
@@ -59,7 +59,7 @@ export const apiDocs = (options) => {
 
         if (!resolvedConfig.plugins.some((plugin) => plugin.name === 'kolay:setup')) {
           throw new Error(
-            `The typedoc() plugin requires the docs() plugin (both from 'kolay/vite') to also be in the plugins array.`
+            `The apiDocs() plugin requires the docs() plugin (both from 'kolay/vite') to also be in the plugins array.`
           );
         }
       },

--- a/src/build/plugins/api-docs/validate.js
+++ b/src/build/plugins/api-docs/validate.js
@@ -40,7 +40,7 @@ function packageExists(entry, cwd) {
 }
 
 /**
- * typedoc() receives a string, or an array of strings, where each entry
+ * apiDocs() receives a string, or an array of strings, where each entry
  * is either
  * - a package name, which must be resolvable from the consuming project
  *   (i.e.: actually installed) — paths within packages are not allowed,
@@ -59,8 +59,8 @@ export function validatePackages(input, cwd) {
 
   if (!Array.isArray(packages)) {
     throw new Error(
-      `typedoc() expects a package name or relative path, or an array of them, ` +
-        `e.g.: typedoc(['my-library', './packages/my-library']). ` +
+      `apiDocs() expects a package name or relative path, or an array of them, ` +
+        `e.g.: apiDocs(['my-library', './packages/my-library']). ` +
         `Received: ${describe(input)}`
     );
   }
@@ -115,7 +115,7 @@ export function validatePackages(input, cwd) {
 
   if (problems.length > 0) {
     throw new Error(
-      `typedoc() received invalid entries:\n` +
+      `apiDocs() received invalid entries:\n` +
         problems.map((problem) => `  - ${problem}`).join('\n')
     );
   }

--- a/src/build/plugins/api-docs/validate.test.ts
+++ b/src/build/plugins/api-docs/validate.test.ts
@@ -78,7 +78,7 @@ describe('validatePackages', () => {
     }
 
     expect(message.replaceAll(cwd, '<cwd>')).toMatchInlineSnapshot(`
-      "typedoc() received invalid entries:
+      "apiDocs() received invalid entries:
         - "nope-xyz": could not be resolved from <cwd>. Is it declared in your package.json, and have you run your package manager's install? (pnpm install / npm install / yarn install)
         - "./missing-xyz": does not exist (resolved to <cwd>/missing-xyz)
         - "unplugin/dist": paths within packages are not supported — type entry points are discovered from the package's package.json#exports. Use "unplugin" instead.

--- a/src/build/plugins/combined.js
+++ b/src/build/plugins/combined.js
@@ -55,7 +55,7 @@ export function docsPlugins(options) {
  *
  * @param {string | string[]} input
  */
-export function typedocPlugins(input) {
+export function apiDocsPlugins(input) {
   const packages = validatePackages(input, process.cwd());
 
   return [apiDocs({ packages })].filter(Boolean);
@@ -76,7 +76,15 @@ export function combinedPlugins(options) {
 }
 
 export const docs = /* #__PURE__ */ createUnplugin(docsPlugins);
-export const typedoc = /* #__PURE__ */ createUnplugin(typedocPlugins);
+
+const apiDocsUnplugin = /* #__PURE__ */ createUnplugin(apiDocsPlugins);
+
+export { apiDocsUnplugin as apiDocs };
+
+/**
+ * @deprecated renamed — use `apiDocs`.
+ */
+export const typedoc = apiDocsUnplugin;
 
 /**
  * @deprecated use `docs` (and `typedoc`, if you have `packages`) instead.

--- a/src/build/plugins/index.d.ts
+++ b/src/build/plugins/index.d.ts
@@ -1,4 +1,4 @@
-export { docs, combined as kolay, typedoc } from './combined.js';
+export { apiDocs, docs, combined as kolay, typedoc } from './combined.js';
 export { gitRef } from './git-ref.js';
 export * as helpers from './helpers.js';
 export type { APIDocsOptions, MarkdownPagesOptions } from '#types';

--- a/src/build/plugins/index.js
+++ b/src/build/plugins/index.js
@@ -1,4 +1,4 @@
 export { generateTypeDocJSON } from './api-docs/typedoc.js';
-export { docs, combined as kolay, typedoc } from './combined.js';
+export { apiDocs, docs, combined as kolay, typedoc } from './combined.js';
 export { gitRef } from './git-ref.js';
 export { packageTypes, virtualFile } from './helpers.js';

--- a/src/build/plugins/markdown-pages/parse.linkEntries.test.ts
+++ b/src/build/plugins/markdown-pages/parse.linkEntries.test.ts
@@ -11,12 +11,12 @@ type Tree = { pages: Array<Node & { pages?: Node[] }> };
 describe('nav-only link entries', () => {
   test('a json config with an href (and no page of its own) becomes an entry', async () => {
     const tree = (await parse(
-      ['development/rendering-pages.md', 'development/configuring-typedoc.json'],
+      ['development/rendering-pages.md', 'development/configuring-api-docs.json'],
       cwd,
       [
         {
-          path: 'development/configuring-typedoc.json',
-          config: { href: '/TypeDoc/plugin/typedoc.md', componentName: 'Configuring typedoc(...)' },
+          path: 'development/configuring-api-docs.json',
+          config: { href: '/TypeDoc/plugin/api-docs.md', title: 'Configuring apiDocs(...)' },
         },
       ]
     )) as unknown as Tree;
@@ -28,29 +28,29 @@ describe('nav-only link entries', () => {
     const names = (development?.pages ?? []).map((node) => node.name);
 
     expect(names).toContain('rendering-pages');
-    expect(names).toContain('configuring-typedoc');
+    expect(names).toContain('configuring-api-docs');
 
-    const link = (development?.pages ?? []).find((node) => node.name === 'configuring-typedoc');
+    const link = (development?.pages ?? []).find((node) => node.name === 'configuring-api-docs');
 
-    expect(link?.href).toBe('/TypeDoc/plugin/typedoc.md');
-    expect(link?.componentName).toBe('Configuring typedoc(...)');
+    expect(link?.href).toBe('/TypeDoc/plugin/api-docs.md');
+    expect(link?.title).toBe('Configuring apiDocs(...)');
   });
 
   test('the group prefix does not apply to the href; the base does', async () => {
-    const tree = (await parse(['development/configuring-typedoc.json'], cwd, [
+    const tree = (await parse(['development/configuring-api-docs.json'], cwd, [
       {
-        path: 'development/configuring-typedoc.json',
-        config: { href: '/TypeDoc/plugin/typedoc.md' },
+        path: 'development/configuring-api-docs.json',
+        config: { href: '/TypeDoc/plugin/api-docs.md' },
       },
     ])) as unknown as Tree;
 
     addPaths(tree as unknown as Parameters<typeof addPaths>[0], '/Home-ish-prefix', '/my-app/');
 
     const development = tree.pages.find((node) => node.name === 'development');
-    const link = (development?.pages ?? []).find((node) => node.name === 'configuring-typedoc');
+    const link = (development?.pages ?? []).find((node) => node.name === 'configuring-api-docs');
 
-    expect(link?.appRelativePath).toBe('/TypeDoc/plugin/typedoc.md');
-    expect(link?.path).toBe('/my-app/TypeDoc/plugin/typedoc.md');
+    expect(link?.appRelativePath).toBe('/TypeDoc/plugin/api-docs.md');
+    expect(link?.path).toBe('/my-app/TypeDoc/plugin/api-docs.md');
   });
 
   test('configs that belong to a page, and meta files, do not become entries', async () => {

--- a/src/build/plugins/setup.js
+++ b/src/build/plugins/setup.js
@@ -77,13 +77,13 @@ export const setup = (options = {}) => {
   let baseUrl = '/';
   let isBuild = false;
   /**
-   * Whether a typedoc() plugin is present in the config — when it isn't,
+   * Whether an apiDocs() plugin is present in the config — when it isn't,
    * this plugin serves an empty 'kolay/api-docs:virtual' so that
    * 'kolay/setup' can always import it. Set accurately during vite's
    * configResolved; the default keeps the fallback dormant so it can
-   * never shadow a real typedoc().
+   * never shadow a real apiDocs().
    */
-  let hasTypedoc = true;
+  let hasApiDocs = true;
 
   return {
     name: 'kolay:setup',
@@ -91,7 +91,7 @@ export const setup = (options = {}) => {
       configResolved(resolvedConfig) {
         baseUrl = resolvedConfig.base;
         isBuild = resolvedConfig.command === 'build';
-        hasTypedoc = resolvedConfig.plugins.some((plugin) => plugin.name === 'kolay:typedoc');
+        hasApiDocs = resolvedConfig.plugins.some((plugin) => plugin.name === 'kolay:apidocs');
 
         resolvedConfig.server ||= {};
         resolvedConfig.server.fs ||= {};
@@ -190,8 +190,8 @@ export const setup = (options = {}) => {
     ...virtualFile([
       {
         importPath: 'kolay/api-docs:virtual',
-        // dormant whenever a typedoc() plugin provides the real thing
-        when: () => !hasTypedoc,
+        // dormant whenever an apiDocs() plugin provides the real thing
+        when: () => !hasApiDocs,
         content: stripIndent`
           export const packageNames = [];
           export const loadApiDocs = {};

--- a/src/build/vite.js
+++ b/src/build/vite.js
@@ -1,4 +1,4 @@
-import { docs as _docs, kolay as _kolay, typedoc as _typedoc } from './plugins/index.js';
+import { apiDocs as _apiDocs, docs as _docs, kolay as _kolay } from './plugins/index.js';
 
 /**
  * The markdown-docs plugin.
@@ -8,7 +8,12 @@ export const docs = _docs.vite;
 /**
  * The api-docs plugin (requires `docs` to also be used).
  */
-export const typedoc = _typedoc.vite;
+export const apiDocs = _apiDocs.vite;
+
+/**
+ * @deprecated renamed — use `apiDocs`.
+ */
+export const typedoc = _apiDocs.vite;
 
 /**
  * @deprecated use `docs` (and `typedoc`, if you have `packages`) instead.

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,12 @@ export interface Page {
   groupName: string;
   cleanedName: string;
   /**
+   * The link text to display for this page in navigation, when the
+   * derived `name` isn't right — set via a json file next to the page:
+   * `{ "title": "selected(...)" }`
+   */
+  title?: string;
+  /**
    * Present on nav-only link entries (a json file with an `href` and no
    * markdown file of its own): the authored link target, as if the app
    * were deployed at '/' — e.g. a page in another group.

--- a/test-apps/custom-root-url/app/templates/application.gts
+++ b/test-apps/custom-root-url/app/templates/application.gts
@@ -4,9 +4,8 @@ import type { TOC } from "@ember/component/template-only";
 import type { Page } from "kolay";
 
 export function nameFor(x: Page) {
-  if ("componentName" in x) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    return `${x.componentName}`;
+  if (x.title) {
+    return x.title;
   }
 
   if (x.path.includes("/components/")) {

--- a/test-apps/custom-root-url/vite.config.mjs
+++ b/test-apps/custom-root-url/vite.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import { docs, typedoc } from "kolay/vite";
+import { docs, apiDocs } from "kolay/vite";
 import { extensions, ember } from "@embroider/vite";
 import { babel } from "@rollup/plugin-babel";
 
@@ -18,7 +18,7 @@ export default defineConfig({
         import { APIDocs, CommentQuery, ComponentSignature, HelperSignature, ModifierSignature } from 'kolay';
         `,
     }),
-    typedoc(["ember-primitives", "ember-resources"]),
+    apiDocs(["ember-primitives", "ember-resources"]),
     ember(),
     babel({
       babelHelpers: "runtime",

--- a/test-apps/markdown-and-gjs-md-app/app/templates/application.gts
+++ b/test-apps/markdown-and-gjs-md-app/app/templates/application.gts
@@ -4,9 +4,8 @@ import type { TOC } from "@ember/component/template-only";
 import type { Page } from "kolay";
 
 export function nameFor(x: Page) {
-  if ("componentName" in x) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    return `${x.componentName}`;
+  if (x.title) {
+    return x.title;
   }
 
   if (x.path.includes("/components/")) {

--- a/test-apps/markdown-and-gjs-md-app/vite.config.mjs
+++ b/test-apps/markdown-and-gjs-md-app/vite.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import { extensions, ember } from "@embroider/vite";
 import { babel } from "@rollup/plugin-babel";
-import { docs, typedoc } from "kolay/vite";
+import { docs, apiDocs } from "kolay/vite";
 
 export default defineConfig({
   plugins: [
@@ -13,7 +13,7 @@ export default defineConfig({
         },
       ],
     }),
-    typedoc(["ember-primitives", "ember-resources"]),
+    apiDocs(["ember-primitives", "ember-resources"]),
     ember(),
     babel({
       babelHelpers: "runtime",

--- a/test-apps/markdown-only/app/templates/application.gts
+++ b/test-apps/markdown-only/app/templates/application.gts
@@ -4,9 +4,8 @@ import type { TOC } from "@ember/component/template-only";
 import type { Page } from "kolay";
 
 export function nameFor(x: Page) {
-  if ("componentName" in x) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    return `${x.componentName}`;
+  if (x.title) {
+    return x.title;
   }
 
   if (x.path.includes("/components/")) {

--- a/test-apps/markdown-only/vite.config.mjs
+++ b/test-apps/markdown-only/vite.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import { extensions, ember } from "@embroider/vite";
 import { babel } from "@rollup/plugin-babel";
-import { docs, typedoc } from "kolay/vite";
+import { docs, apiDocs } from "kolay/vite";
 
 export default defineConfig({
   plugins: [
@@ -16,7 +16,7 @@ export default defineConfig({
         import { APIDocs, CommentQuery, ComponentSignature, HelperSignature, ModifierSignature } from 'kolay';
         `,
     }),
-    typedoc(["ember-primitives", "ember-resources"]),
+    apiDocs(["ember-primitives", "ember-resources"]),
     ember(),
     babel({
       babelHelpers: "runtime",


### PR DESCRIPTION
Follow-up to #329/#331.

## `typedoc()` → `apiDocs()`

```js
import { docs, apiDocs } from "kolay/vite";

plugins: [docs({ ... }), apiDocs(["my-library"])]
```

- `typedoc` stays exported as a deprecated alias (same plugin), so nothing breaks this release
- the vite plugin name is now `kolay:apidocs`; `docs()`'s fallback-virtual detection follows
- validation and requires-docs errors say `apiDocs()`; "typedoc" in code/docs now refers only to the technology producing the JSON (`generateTypeDocJSON`, the TypeDoc docs group, the renderer components keep their names)
- the TypeDoc group's plugin page moves to `/TypeDoc/plugin/api-docs.md`, retitled `apiDocs(...)`; the Development nav-link entry renames to `configuring-api-docs` ("Configuring apiDocs(...)")

## `componentName` → `title`

The per-page json key for nav link text is now `title` — `{ "title": "selected(...)" }`:

- every page json in the repo converted; `Page` gains a typed, documented optional `title`
- the `nameFor` helpers in the docs-app and all test-apps read `page.title`
- the Renaming-pages docs page updated (it now describes the key as "the link text")

Since json config keys pass through the manifest opaquely, existing consumers using `componentName` with their own `nameFor` are unaffected.

## Testing

docs-app suite (45), markdown-only, markdown-and-gjs-md-app, custom-root-url (9/9): all green; vitest (90, including the regenerated aggregate-error snapshot and retargeted link-entry tests) + full repo lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)