### PR TITLE
docs-app: memory-scroll page behavior; Ecosystem docs section

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -68,6 +68,7 @@
     "ember-template-lint": "^7.9.3",
     "eslint": "^9.39.2",
     "loader.js": "^4.7.0",
+    "memory-scroll": "^2.0.1",
     "prettier": "^3.7.4",
     "prettier-plugin-ember-template-tag": "^2.1.2",
     "qunit": "^2.24.1",

--- a/docs-app/src/services/memory-scroll.ts
+++ b/docs-app/src/services/memory-scroll.ts
@@ -1,0 +1,3 @@
+// the docs-app uses an explicit resolver registry (src/registry.ts), so
+// addon services need a local re-export to be found
+export { default } from 'memory-scroll/services/memory-scroll';

--- a/docs-app/src/templates/application.gts
+++ b/docs-app/src/templates/application.gts
@@ -16,6 +16,7 @@ import { ExternalLink } from 'nvp.ui';
 import { abbreviatedSha } from '~build/git';
 
 import type { TOC } from '@ember/component/template-only';
+import type Owner from '@ember/owner';
 import type RouterService from '@ember/routing/router-service';
 import type { Page } from 'kolay';
 import type MemoryScrollService from 'memory-scroll/services/memory-scroll';
@@ -34,7 +35,7 @@ class ScrollBehavior extends Component {
   @service declare router: RouterService;
   @service('memory-scroll') declare memory: MemoryScrollService;
 
-  constructor(owner: unknown, args: Record<string, unknown>) {
+  constructor(owner: Owner, args: Record<string, unknown>) {
     super(owner, args);
 
     // keep the browser-restored position on reload: seed the initial
@@ -43,11 +44,11 @@ class ScrollBehavior extends Component {
   }
 
   get key(): string {
-    this.router.currentURL; // recompute on every navigation
-
+    // reading currentURL makes this recompute on every navigation
+    const url = this.router.currentURL;
     const state = window.history.state as { uuid?: string } | null;
 
-    return String(state?.uuid ?? this.router.currentURL);
+    return String(state?.uuid ?? url);
   }
 
   <template>

--- a/docs-app/src/templates/application.gts
+++ b/docs-app/src/templates/application.gts
@@ -1,6 +1,8 @@
 import 'ember-mobile-menu/themes/android';
 
+import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
+import { service } from '@ember/service';
 
 import { pascalCase, sentenceCase } from 'change-case';
 // @ts-expect-error no types for the mobile-menu
@@ -8,12 +10,50 @@ import MenuWrapper from 'ember-mobile-menu/components/mobile-menu-wrapper';
 import { pageTitle } from 'ember-page-title';
 import Route from 'ember-route-template';
 import { GroupNav, PageNav } from 'kolay/components';
+import rememberDocumentScroll from 'memory-scroll/modifiers/remember-document-scroll';
 import { ExternalLink } from 'nvp.ui';
 
 import { abbreviatedSha } from '~build/git';
 
 import type { TOC } from '@ember/component/template-only';
+import type RouterService from '@ember/routing/router-service';
 import type { Page } from 'kolay';
+import type MemoryScrollService from 'memory-scroll/services/memory-scroll';
+
+/**
+ * Navigating to a page scrolls to the top; going back (or forward)
+ * restores that history entry's scroll position.
+ *
+ * Each history entry has its own uuid (stamped by Ember's location),
+ * so a link click produces a fresh key — memory-scroll finds no saved
+ * position and scrolls to 0 — while back/forward reuses the entry's
+ * key and restores. Positions are recorded live by the modifier's
+ * scroll listener.
+ */
+class ScrollBehavior extends Component {
+  @service declare router: RouterService;
+  @service('memory-scroll') declare memory: MemoryScrollService;
+
+  constructor(owner: unknown, args: Record<string, unknown>) {
+    super(owner, args);
+
+    // keep the browser-restored position on reload: seed the initial
+    // entry's memory before the modifier's first restore runs
+    this.memory.memory.set(this.key, document.documentElement.scrollTop);
+  }
+
+  get key(): string {
+    this.router.currentURL; // recompute on every navigation
+
+    const state = window.history.state as { uuid?: string } | null;
+
+    return String(state?.uuid ?? this.router.currentURL);
+  }
+
+  <template>
+    <div aria-hidden="true" {{rememberDocumentScroll key=this.key}}></div>
+  </template>
+}
 
 const Menu: TOC<{ Element: SVGElement }> = <template>
   <svg x="0px" y="0px" viewBox="0 0 50 50" style="fill:currentColor" ...attributes><path
@@ -60,6 +100,7 @@ export default Route(
       </mmw.MobileMenu>
 
       <mmw.Content class="container">
+        <ScrollBehavior />
         <header>
           <div>
             <mmw.Toggle><Menu /></mmw.Toggle>

--- a/docs-app/src/templates/ecosystem/ember-primitives.gjs.md
+++ b/docs-app/src/templates/ecosystem/ember-primitives.gjs.md
@@ -1,6 +1,8 @@
 # ember-primitives
 
-[ember-primitives](https://ember-primitives.pages.dev) supplies several of the pieces kolay builds on — and one it requires:
+[Documentation](https://ember-primitives.pages.dev) · [GitHub](https://github.com/universal-ember/ember-primitives)
+
+ember-primitives supplies several of the pieces kolay builds on — and one it requires:
 
 ## `@properLinks` (required)
 

--- a/docs-app/src/templates/ecosystem/ember-primitives.gjs.md
+++ b/docs-app/src/templates/ecosystem/ember-primitives.gjs.md
@@ -1,0 +1,34 @@
+# ember-primitives
+
+[ember-primitives](https://ember-primitives.pages.dev) supplies several of the pieces kolay builds on — and one it requires:
+
+## `@properLinks` (required)
+
+Markdown renders plain `<a>` tags. The `@properLinks` decorator on your router turns same-app anchor clicks into router transitions, which is what makes links between docs pages work:
+
+```js
+import { properLinks } from "ember-primitives/proper-links";
+
+@properLinks
+export default class Router extends EmberRouter {
+  /* ... */
+}
+```
+
+## `<Shadowed>`
+
+Available in every live codefence by default (via the runtime scope): renders its content inside shadow DOM, giving demos a clean style sandbox so page styles and demo styles can't leak into each other.
+
+```hbs
+<Shadowed>
+  <MyDemoWithItsOwnStyles />
+</Shadowed>
+```
+
+## `createStore`
+
+Kolay's browser state — [`docsManager(...)`](/Runtime/utilities/docs-manager.md) and [`selected(...)`](/Runtime/utilities/selected.md) — is built on `ember-primitives/store`: owner-linked singletons you reach from any component, no service files required.
+
+## Color scheme
+
+This site's light/dark handling uses `ember-primitives/color-scheme` (`sync()` + `colorScheme.current`), e.g. for giving shiki the right theme at runtime.

--- a/docs-app/src/templates/ecosystem/ember-primitives.json
+++ b/docs-app/src/templates/ecosystem/ember-primitives.json
@@ -1,0 +1,1 @@
+{ "title": "ember-primitives" }

--- a/docs-app/src/templates/ecosystem/ember-repl.gjs.md
+++ b/docs-app/src/templates/ecosystem/ember-repl.gjs.md
@@ -1,0 +1,22 @@
+# ember-repl
+
+[ember-repl](https://limber.glimdown.com/docs/ember-repl) (with [repl-sdk](https://limber.glimdown.com/docs/repl-sdk) underneath) is the compiler behind everything kolay renders:
+
+- **`.md` pages** compile in the browser: `setupKolay()` configures an ember-repl compiler per application (your `remarkPlugins` / `rehypePlugins` / `topLevelScope` / `modules` feed straight into it), and [`selected`](/Runtime/utilities/selected.md) / [`compiledDoc`](/Runtime/rendering/compiled-doc.md) / [`Compiled`](/Runtime/rendering/compiled.md) all compile through it.
+- **`.gjs.md` pages** compile at build time: the `docs()` plugin runs repl-sdk's markdown pipeline (the same one) in vite, so live codefences become real components in your bundle.
+- **[Live codefences](/authoring/code-fences.md)** — the `live` / `preview` / `below` flags and the [render targets](/authoring/code-fences.md#render-targets) (gjs, hbs, jsx, svelte, vue, mermaid, …) are ember-repl / repl-sdk features; kolay configures which are allowed per compile mode.
+
+## In tests
+
+`setupKolay` from `kolay/test-support` wires the compiler up with `setupCompiler` from `ember-repl/test-support`, so rendering tests can compile markdown the same way the app does:
+
+```js
+import { setupKolay } from "kolay/test-support";
+
+module("my docs", function (hooks) {
+  setupRenderingTest(hooks);
+  setupKolay(hooks);
+
+  // ...render <Page /> or Compiled(...) as usual
+});
+```

--- a/docs-app/src/templates/ecosystem/ember-repl.gjs.md
+++ b/docs-app/src/templates/ecosystem/ember-repl.gjs.md
@@ -1,6 +1,8 @@
 # ember-repl
 
-[ember-repl](https://limber.glimdown.com/docs/ember-repl) (with [repl-sdk](https://limber.glimdown.com/docs/repl-sdk) underneath) is the compiler behind everything kolay renders:
+[Documentation](https://limber.glimdown.com/docs/ember-repl) · [GitHub](https://github.com/NullVoxPopuli/limber) — repl-sdk: [Documentation](https://limber.glimdown.com/docs/repl-sdk)
+
+ember-repl (with repl-sdk underneath) is the compiler behind everything kolay renders:
 
 - **`.md` pages** compile in the browser: `setupKolay()` configures an ember-repl compiler per application (your `remarkPlugins` / `rehypePlugins` / `topLevelScope` / `modules` feed straight into it), and [`selected`](/Runtime/utilities/selected.md) / [`compiledDoc`](/Runtime/rendering/compiled-doc.md) / [`Compiled`](/Runtime/rendering/compiled.md) all compile through it.
 - **`.gjs.md` pages** compile at build time: the `docs()` plugin runs repl-sdk's markdown pipeline (the same one) in vite, so live codefences become real components in your bundle.

--- a/docs-app/src/templates/ecosystem/ember-repl.json
+++ b/docs-app/src/templates/ecosystem/ember-repl.json
@@ -1,0 +1,1 @@
+{ "title": "ember-repl" }

--- a/docs-app/src/templates/ecosystem/memory-scroll.gjs.md
+++ b/docs-app/src/templates/ecosystem/memory-scroll.gjs.md
@@ -1,0 +1,38 @@
+# memory-scroll
+
+[memory-scroll](https://github.com/ef4/memory-scroll) provides modifiers for keeping scroll positions sensible as users navigate. This site uses it for its page-scroll behavior: navigating to a page scrolls to the top, while going back (or forward) restores that history entry's position.
+
+The whole behavior is one modifier — `rememberDocumentScroll` — keyed by the current history entry:
+
+```gts
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import rememberDocumentScroll from "memory-scroll/modifiers/remember-document-scroll";
+
+class ScrollBehavior extends Component {
+  @service router;
+
+  get key() {
+    this.router.currentURL; // recompute on every navigation
+
+    return String(window.history.state?.uuid ?? this.router.currentURL);
+  }
+
+  <template>
+    <div aria-hidden="true" {{rememberDocumentScroll key=this.key}}></div>
+  </template>
+}
+```
+
+Why the history entry's `uuid` (stamped by Ember's location) instead of the URL: a link click creates a fresh entry — a key memory-scroll has never seen, so it scrolls to `0` — while back/forward revisits an existing entry, whose position the modifier has been recording live. The same page reached two different ways behaves correctly in both.
+
+Render it once, anywhere that's always on screen (this site puts it in the application template).
+
+If your app resolves services from an explicit module registry, re-export the addon's service so it can be found:
+
+```js
+// app/services/memory-scroll.js
+export { default } from "memory-scroll/services/memory-scroll";
+```
+
+memory-scroll also ships `memoryScroll` (remember an individual scrollable element's position) and `scrollTo` (always scroll to a position when a key changes) for finer-grained control.

--- a/docs-app/src/templates/ecosystem/memory-scroll.gjs.md
+++ b/docs-app/src/templates/ecosystem/memory-scroll.gjs.md
@@ -1,6 +1,8 @@
 # memory-scroll
 
-[memory-scroll](https://github.com/ef4/memory-scroll) provides modifiers for keeping scroll positions sensible as users navigate. This site uses it for its page-scroll behavior: navigating to a page scrolls to the top, while going back (or forward) restores that history entry's position.
+[GitHub](https://github.com/ef4/memory-scroll) (the README is the documentation) · [npm](https://www.npmjs.com/package/memory-scroll)
+
+memory-scroll provides modifiers for keeping scroll positions sensible as users navigate. This site uses it for its page-scroll behavior: navigating to a page scrolls to the top, while going back (or forward) restores that history entry's position.
 
 The whole behavior is one modifier — `rememberDocumentScroll` — keyed by the current history entry:
 

--- a/docs-app/src/templates/ecosystem/memory-scroll.json
+++ b/docs-app/src/templates/ecosystem/memory-scroll.json
@@ -1,0 +1,1 @@
+{ "title": "memory-scroll" }

--- a/docs-app/src/templates/ecosystem/meta.json
+++ b/docs-app/src/templates/ecosystem/meta.json
@@ -1,0 +1,3 @@
+{
+  "order": ["memory-scroll", "ember-primitives", "ember-repl"]
+}

--- a/docs-app/src/templates/meta.jsonc
+++ b/docs-app/src/templates/meta.jsonc
@@ -1,4 +1,4 @@
 {
   // Install first, helpers last
-  "order": ["install", "authoring", "development", "migrations"],
+  "order": ["install", "authoring", "development", "migrations", "ecosystem"],
 }

--- a/docs-app/tests/docs-app/home-nav-test.gts
+++ b/docs-app/tests/docs-app/home-nav-test.gts
@@ -11,7 +11,7 @@ module('Home docs navigation', function (hooks) {
     const nav = document.querySelector('aside nav');
     const text = nav?.textContent?.replaceAll(/\s+/g, ' ') ?? '';
 
-    const sections = ['Install', 'Authoring', 'Development', 'Migrations'];
+    const sections = ['Install', 'Authoring', 'Development', 'Migrations', 'Ecosystem'];
     const positions = sections.map((section) => text.indexOf(section));
 
     assert.deepEqual(
@@ -25,6 +25,13 @@ module('Home docs navigation', function (hooks) {
       positions,
       'sections are in order'
     );
+  });
+
+  test('the scroll-behavior element is wired up', async function (assert) {
+    await visit('/install/index');
+
+    assert.ok(this.owner.lookup('service:memory-scroll'), 'memory-scroll service resolves');
+    assert.dom('.mobile-menu-wrapper__content > [aria-hidden]').exists('the keyed element renders');
   });
 
   test('visiting the root redirects to the first page of the default group', async function (assert) {
@@ -48,6 +55,9 @@ module('Home docs navigation', function (hooks) {
       ['/authoring/extending-markdown', 'Extending markdown'],
       ['/Runtime/rendering/compiled', 'Compiled'],
       ['/migrations/upgrading-from-5x', 'Upgrading from 5.x'],
+      ['/ecosystem/memory-scroll', 'memory-scroll'],
+      ['/ecosystem/ember-primitives', 'ember-primitives'],
+      ['/ecosystem/ember-repl', 'ember-repl'],
     ]) {
       await visit(url as string);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       loader.js:
         specifier: ^4.7.0
         version: 4.7.0
+      memory-scroll:
+        specifier: ^2.0.1
+        version: 2.0.1(@babel/core@7.29.6)
       prettier:
         specifier: ^3.7.4
         version: 3.8.1
@@ -6448,6 +6451,9 @@ packages:
   mem@8.1.1:
     resolution: {integrity: sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==}
     engines: {node: '>=10'}
+
+  memory-scroll@2.0.1:
+    resolution: {integrity: sha512-SuAFm2qNUqAuJ4mIyq4JhPe7EAuFy1pR0GIv+TbXbSqi9hkUTGq4XtFthE/eDpyiW4y6+7d/39ntJxeBy/atvQ==}
 
   memory-streams@0.1.3:
     resolution: {integrity: sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==}
@@ -16321,6 +16327,15 @@ snapshots:
     dependencies:
       map-age-cleaner: 0.1.3
       mimic-fn: 3.1.0
+
+  memory-scroll@2.0.1(@babel/core@7.29.6):
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.3.1(@babel/core@7.29.6)
+      ember-modifier: 4.3.0(@babel/core@7.29.6)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   memory-streams@0.1.3:
     dependencies:


### PR DESCRIPTION
## Scroll behavior (ef4's memory-scroll)

Navigating to a page scrolls to the top; going back (or forward) restores that history entry's position.

It's one modifier — `rememberDocumentScroll` — keyed by the **history entry's uuid** (stamped by Ember's location): a link click mints a fresh entry, memory-scroll finds no saved position and scrolls to `0`; back/forward revisits an entry whose position the modifier has been recording live via its scroll listener. The same URL reached both ways behaves correctly. Two extra touches: the initial entry is seeded with the browser-restored position so reloads keep their place, and the addon's service gets a local re-export (`app/services/memory-scroll`) because the app resolves from an explicit module registry.

Re: the gjs/gts question — memory-scroll 2.x **is** authored in gjs/gts (`.gts` components, `.ts` modifiers/services, v2 addon, updated 2025), so it drops straight in; no upstream migration PR needed.

Verified live in the browser: scroll to 800 → click a link → lands at 0 → `history.back()` → restored to 800. A test asserts the service + keyed element are wired (scroll physics aren't reachable from the testem container).

## Ecosystem section

New Home-group section after Migrations, one page per integration:

- **memory-scroll** — the recipe above, why the key is the history uuid rather than the URL, and the registry re-export note
- **ember-primitives** — `@properLinks` (required, it's what makes markdown's plain `<a>` tags route), `<Shadowed>`, `createStore` (what `docsManager`/`selected` are built on), color-scheme
- **ember-repl** — the compiler behind both compile modes, live codefences/render targets, and `setupCompiler` via `kolay/test-support` in tests

Nav order/section tests updated; page-render sweep covers the three new pages. docs-app 47/47, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)