### PR TITLE
docs-app: drop the README aside from the memory-scroll links row

### DIFF
--- a/docs-app/src/templates/ecosystem/memory-scroll.gjs.md
+++ b/docs-app/src/templates/ecosystem/memory-scroll.gjs.md
@@ -1,6 +1,6 @@
 # memory-scroll
 
-[GitHub](https://github.com/ef4/memory-scroll) (the README is the documentation) · [npm](https://www.npmjs.com/package/memory-scroll)
+[GitHub](https://github.com/ef4/memory-scroll) · [npm](https://www.npmjs.com/package/memory-scroll)
 
 memory-scroll provides modifiers for keeping scroll positions sensible as users navigate. This site uses it for its page-scroll behavior: navigating to a page scrolls to the top, while going back (or forward) restores that history entry's position.
 


### PR DESCRIPTION
Removes the parenthetical "(the README is the documentation)" from the links row on the Ecosystem → memory-scroll page.

Stacked on #334 — will show only the one-line diff once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)