### PR TITLE
docs: show the CompileState that Compiled gives back

### DIFF
--- a/docs-app/tests/docs-app/runtime-nav-test.gts
+++ b/docs-app/tests/docs-app/runtime-nav-test.gts
@@ -46,6 +46,22 @@ module('Runtime docs navigation', function (hooks) {
     assert.dom('.home-doc[data-design="home"]').exists();
   });
 
+  test('the Compiled page shows the CompileState it gives back', async function (assert) {
+    await visit('/Runtime/rendering/compiled.md');
+
+    assert.dom('[data-page-error]').doesNotExist();
+
+    const section = [...document.querySelectorAll('h3')].find((h3) =>
+      h3.textContent?.includes('CompileState')
+    );
+
+    assert.ok(section, 'the CompileState section exists');
+
+    for (const field of ['component', 'error', 'isReady', 'promise', 'reason']) {
+      assert.dom('.runtime-doc').containsText(field);
+    }
+  });
+
   test('page links use the invocation style of their APIs', async function (assert) {
     await visit('/Runtime/rendering/page.md');
 

--- a/docs-app/vite.config.js
+++ b/docs-app/vite.config.js
@@ -43,7 +43,7 @@ export default defineConfig(async ({ mode }) => {
         src: import.meta.resolve('../docs-typedoc', import.meta.url),
         ...sharedMarkdownOptions,
       }),
-      apiDocs(['kolay', 'ember-primitives', 'ember-resources']),
+      apiDocs(['kolay', 'ember-primitives', 'ember-resources', 'ember-repl']),
       babel({
         babelHelpers: 'runtime',
         extensions,

--- a/docs/rendering/compiled.gjs.md
+++ b/docs/rendering/compiled.gjs.md
@@ -44,3 +44,9 @@ const doc = `Hello from **a string**!`;
 ## API Reference
 
 <APIDocs @module="declarations/browser" @name="Compiled" @package="kolay" />
+
+### `CompileState`
+
+The state `Compiled` gives back is [ember-repl](/ecosystem/ember-repl)'s `CompileState`:
+
+<APIDocs @module="declarations" @name="CompileState" @package="ember-repl" />


### PR DESCRIPTION
Runtime → Rendering → `Compiled(...)` described the compile state in a code comment but never showed the actual shape.

- `ember-repl` is now in the docs-app's `apiDocs([...])` packages, so its types render like kolay's own.
- The page's API Reference gains a `CompileState` section — `<APIDocs @package="ember-repl" @module="declarations" @name="CompileState" />` — with a link to the Ecosystem → ember-repl page.
- Test: visits the page and asserts the section and its fields render (docs-app 48/48, lint 21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)