### PR TITLE
docs: show the Selected store that selected() returns

### DIFF
--- a/docs-app/tests/docs-app/runtime-nav-test.gts
+++ b/docs-app/tests/docs-app/runtime-nav-test.gts
@@ -64,4 +64,29 @@ module('Runtime docs navigation', function (hooks) {
       assert.dom('aside nav').containsText(label);
     }
   });
+
+  test('the selected page shows the Selected store it returns', async function (assert) {
+    await visit('/Runtime/utilities/selected.md');
+
+    assert.dom('[data-page-error]').doesNotExist();
+
+    const section = [...document.querySelectorAll('h3')].find((h3) =>
+      h3.textContent?.includes('Selected')
+    );
+
+    assert.ok(section, 'the Selected section exists');
+
+    for (const member of ['doc', 'prose', 'isReady', 'isPending', 'hasError', 'error']) {
+      assert.dom('.runtime-doc').containsText(member);
+    }
+
+    assert
+      .dom('.runtime-doc')
+      .containsText(
+        'A human-readable error message',
+        'accessor doc comments render (they live on the get signature)'
+      );
+
+    assert.dom('.runtime-doc').doesNotContainText('router', 'private members stay hidden');
+  });
 });

--- a/docs/utilities/selected.gjs.md
+++ b/docs/utilities/selected.gjs.md
@@ -53,3 +53,9 @@ To render a document that is _not_ the current page (something you fetched yours
 ## API Reference
 
 <APIDocs @module="declarations/browser" @name="selected" @package="kolay" />
+
+### `Selected`
+
+The store `selected` returns:
+
+<APIDocs @module="declarations/browser" @name="Selected" @package="kolay" />

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -27,3 +27,4 @@ export type { Collection, Manifest, Page } from '../types.ts';
 export type { DocsGroupModule, MetaManifest } from './load-compiled-docs.ts';
 export type { DocModule, DocSource } from './services/compiled-doc.ts';
 export type { SetupOptions } from './services/docs.ts';
+export type { Selected } from './services/selected.ts';

--- a/src/browser/services/selected.ts
+++ b/src/browser/services/selected.ts
@@ -22,9 +22,16 @@ export function selected(context: unknown) {
 type File = { default: string | ComponentLike };
 type Loader = () => Promise<File>;
 
+/**
+ * The store `selected(context)` returns.
+ */
 class Selected {
-  @service declare router: RouterService;
+  @service declare private router: RouterService;
 
+  /**
+   * The page-module map — path to document loader.
+   * `setupKolay` fills this in; reading it directly is rarely needed.
+   */
   compiledDocs: Record<string, Loader> = {};
 
   get #docs() {
@@ -47,6 +54,12 @@ class Selected {
     return fn?.();
   });
 
+  /**
+   * The rendered document (a component), if ready.
+   *
+   * While a new page loads (or after it errored), this keeps the
+   * previously rendered page, so navigation doesn't flash an empty screen.
+   */
   get prose() {
     if (this.error) {
       return;
@@ -55,14 +68,23 @@ class Selected {
     return this.doc.prose;
   }
 
+  /**
+   * Has the current page finished loading and compiling?
+   */
   get isReady() {
     return this.doc.isReady;
   }
 
+  /**
+   * Is the current page still loading / compiling?
+   */
   get isPending() {
     return !this.isReady;
   }
 
+  /**
+   * Did resolving the page, loading, or compiling fail?
+   */
   get hasError() {
     if (this.error) {
       return Boolean(this.error);
@@ -71,6 +93,9 @@ class Selected {
     return this.doc.hasError;
   }
 
+  /**
+   * A human-readable error message; `''` when there is none.
+   */
   @cached
   get error() {
     if (!this.#page) {
@@ -90,6 +115,9 @@ class Selected {
     return error;
   }
 
+  /**
+   * `Boolean(this.prose)`
+   */
   get hasProse() {
     return Boolean(this.prose);
   }
@@ -147,3 +175,5 @@ class Selected {
     console.groupEnd();
   }
 }
+
+export type { Selected };

--- a/src/browser/typedoc/renderer.gts
+++ b/src/browser/typedoc/renderer.gts
@@ -161,6 +161,11 @@ const Declaration: TOC<{
         <div class='typedoc__declaration-type'>
           <Type @info={{@info.type}} />
         </div>
+      {{else if @info.getSignature.type}}
+        {{! accessors keep their type on the get signature }}
+        <div class='typedoc__declaration-type'>
+          <Type @info={{@info.getSignature.type}} />
+        </div>
       {{/if}}
 
       {{#if @info.children}}
@@ -183,6 +188,9 @@ const Declaration: TOC<{
       {{#if (not (isConst @info))}}
         {{#if @info.comment.summary}}
           <Comment @info={{@info}} />
+        {{else if @info.getSignature.comment.summary}}
+          {{! accessors keep their comment on the get signature }}
+          <Comment @info={{@info.getSignature}} />
         {{/if}}
       {{/if}}
     </div>


### PR DESCRIPTION
Runtime → Utilities → `selected(...)` listed the store's members in a code comment but never showed the actual shape.

- `Selected` is exported (type-only) from `kolay` and rendered on the page via `<APIDocs @name="Selected" />`, with doc comments added to its public members. The `router` service injection is `private` so typedoc excludes it.
- Renderer fix along the way: accessors keep their type and comment on the **get signature**, which `<APIDocs />` ignored — getters rendered as bare names with no type badge or description. `Declaration` now falls back to `getSignature.type` / `getSignature.comment`, which also improves every other class/interface rendered anywhere (e.g. `CompileState` in #337).
- Test: visits the page, asserts the section, member names, an accessor comment, and that `router` stays hidden. docs-app 48/48, lint 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)