### PR TITLE
docs: show the DocsService store that docsManager() returns

### DIFF
--- a/docs-app/tests/docs-app/runtime-nav-test.gts
+++ b/docs-app/tests/docs-app/runtime-nav-test.gts
@@ -89,4 +89,36 @@ module('Runtime docs navigation', function (hooks) {
 
     assert.dom('.runtime-doc').doesNotContainText('router', 'private members stay hidden');
   });
+
+  test('the docsManager page shows the DocsService store it returns', async function (assert) {
+    await visit('/Runtime/utilities/docs-manager.md');
+
+    assert.dom('[data-page-error]').doesNotExist();
+
+    const section = [...document.querySelectorAll('h3')].find((h3) =>
+      h3.textContent?.includes('DocsService')
+    );
+
+    assert.ok(section, 'the DocsService section exists');
+
+    for (const member of [
+      'manifest',
+      'pages',
+      'tree',
+      'selectedGroup',
+      'availableGroups',
+      'currentGroup',
+      'groupFor',
+      'groupForURL',
+      'findByPath',
+      'hrefFor',
+      'appRelativeHrefFor',
+      'groupHrefFor',
+      'selectGroup',
+    ]) {
+      assert.dom('.runtime-doc').containsText(member);
+    }
+
+    assert.dom('.runtime-doc').doesNotContainText('PREPARE_DOCS', 'internal wiring stays hidden');
+  });
 });

--- a/docs-app/tests/docs-app/runtime-nav-test.gts
+++ b/docs-app/tests/docs-app/runtime-nav-test.gts
@@ -64,4 +64,29 @@ module('Runtime docs navigation', function (hooks) {
       assert.dom('aside nav').containsText(label);
     }
   });
+
+  test('the selected page shows the Selected store it returns', async function (assert) {
+    await visit('/Runtime/utilities/selected.md');
+
+    assert.dom('[data-page-error]').doesNotExist();
+
+    const section = [...document.querySelectorAll('h3')].find((h3) =>
+      h3.textContent?.includes('Selected')
+    );
+
+    assert.ok(section, 'the Selected section exists');
+
+    for (const member of ['doc', 'prose', 'isReady', 'isPending', 'hasError', 'error']) {
+      assert.dom('.runtime-doc').containsText(member);
+    }
+
+    assert
+      .dom('.runtime-doc')
+      .containsText(
+        'A human-readable error message',
+        'accessor doc comments render (they live on the get signature)'
+      );
+
+    assert.dom('.runtime-doc').doesNotContainText('router', 'private members stay hidden');
+  });
 });

--- a/docs/utilities/docs-manager.gjs.md
+++ b/docs/utilities/docs-manager.gjs.md
@@ -30,3 +30,9 @@ At the default `rootURL` of `/`, the two are identical.
 ## API Reference
 
 <APIDocs @module="declarations/browser" @name="docsManager" @package="kolay" />
+
+### `DocsService`
+
+The store `docsManager` returns:
+
+<APIDocs @module="declarations/browser" @name="DocsService" @package="kolay" />

--- a/docs/utilities/selected.gjs.md
+++ b/docs/utilities/selected.gjs.md
@@ -53,3 +53,9 @@ To render a document that is _not_ the current page (something you fetched yours
 ## API Reference
 
 <APIDocs @module="declarations/browser" @name="selected" @package="kolay" />
+
+### `Selected`
+
+The store `selected` returns:
+
+<APIDocs @module="declarations/browser" @name="Selected" @package="kolay" />

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -27,4 +27,5 @@ export type { Collection, Manifest, Page } from '../types.ts';
 export type { DocsGroupModule, MetaManifest } from './load-compiled-docs.ts';
 export type { DocModule, DocSource } from './services/compiled-doc.ts';
 export type { SetupOptions } from './services/docs.ts';
+export type { DocsService } from './services/docs.ts';
 export type { Selected } from './services/selected.ts';

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -27,3 +27,4 @@ export type { Collection, Manifest, Page } from '../types.ts';
 export type { DocsGroupModule, MetaManifest } from './load-compiled-docs.ts';
 export type { DocModule, DocSource } from './services/compiled-doc.ts';
 export type { SetupOptions } from './services/docs.ts';
+export type { Selected } from './services/selected.ts';

--- a/src/browser/services/docs.ts
+++ b/src/browser/services/docs.ts
@@ -92,7 +92,7 @@ export function compilerOptions({
  * group, and helpers for resolving pages and building hrefs.
  */
 class DocsService {
-  @service private declare router: RouterService;
+  @service declare private router: RouterService;
 
   private get apiDocs() {
     return typedocLoader(this);

--- a/src/browser/services/docs.ts
+++ b/src/browser/services/docs.ts
@@ -16,7 +16,7 @@ import { typedocLoader } from './api-docs.ts';
 import { getKey } from './lazy-load.ts';
 import { selected } from './selected.ts';
 
-import type { LoadManifest, LoadTypedoc, Manifest, Page } from '../../types.ts';
+import type { LoadTypedoc, Manifest, Page } from '../../types.ts';
 import type RouterService from '@ember/routing/router-service';
 import type { ComponentLike } from '@glint/template';
 
@@ -87,8 +87,12 @@ export function compilerOptions({
   };
 }
 
+/**
+ * The store `docsManager(context)` returns: the manifest, the current
+ * group, and helpers for resolving pages and building hrefs.
+ */
 class DocsService {
-  @service declare router: RouterService;
+  @service private declare router: RouterService;
 
   private get apiDocs() {
     return typedocLoader(this);
@@ -98,10 +102,12 @@ class DocsService {
     return selected(this);
   }
 
-  _docs: Manifest | undefined;
+  private _docs: Manifest | undefined;
 
-  loadManifest: LoadManifest = () => Promise.resolve({ base: '/', groups: [] });
-
+  /**
+   * Wires the loaded docs modules into the store.
+   * The generated `setupKolay` calls this — apps rarely call it directly.
+   */
   setup = async (options: {
     /**
      * The module of the api docs virtual module.
@@ -170,6 +176,11 @@ class DocsService {
     return this.manifest;
   };
 
+  /**
+   * Internal wiring shared by `setup` and the test-support helpers.
+   *
+   * @private
+   */
   [PREPARE_DOCS](
     apiDocs: { packageNames: string[]; loadApiDocs: LoadTypedoc } | undefined,
     compiledDocs:
@@ -193,7 +204,7 @@ class DocsService {
     }
   }
 
-  get docs() {
+  private get docs() {
     assert(
       `Docs' manifest was not loaded. Be sure to call setup() before accessing anything on the docs service.`,
       this._docs
@@ -202,6 +213,9 @@ class DocsService {
     return this._docs;
   }
 
+  /**
+   * The loaded manifest: the app's `base` (rootURL) and every group.
+   */
   get manifest() {
     return this.docs;
   }
@@ -222,13 +236,11 @@ class DocsService {
   }
 
   /**
-   * We use the URL for denoting which group we're looking at.
-   * The first segment of the URL will either be a group,
-   * or part of the path segment on the root namespace.
+   * The name of the group currently being viewed.
    *
-   * This does open us up for collisions, so maybe
-   * we'll need to alias "root" with something, or at
-   * the very least not use a non-path segement for it.
+   * The first URL segment names the group — unless the current route is
+   * inside a scoped mount (`addRoutes(context, groupName)`), in which
+   * case the mount decides.
    */
   get selectedGroup() {
     // A scoped mount (addRoutes(context, groupName)) decides the group,
@@ -351,6 +363,10 @@ class DocsService {
     return this.router.urlFor(indexRouteNameFor(mountRoute));
   };
 
+  /**
+   * Navigate to a group's first page (or its mount's own URL, for a
+   * scoped mount).
+   */
   selectGroup = (group: string) => {
     assert(
       `Expected group name, ${group}, to be one of ${this.availableGroups.join(', ')}`,
@@ -375,17 +391,27 @@ class DocsService {
     this.router.transitionTo(`/${group}`);
   };
 
+  /**
+   * Every group's name, in manifest order.
+   */
   get availableGroups() {
     const groups = this.manifest?.groups ?? [];
 
     return groups.map((group) => group.name);
   }
 
+  /**
+   * The manifest entry for `selectedGroup`.
+   */
   @cached
   get currentGroup() {
     return this.groupFor(this.selectedGroup);
   }
 
+  /**
+   * The manifest entry for a group, by name. Asserts if the group
+   * doesn't exist.
+   */
   groupFor = (groupName: string | undefined) => {
     const groups = this.manifest?.groups ?? [];
 
@@ -427,3 +453,5 @@ class DocsService {
     );
   };
 }
+
+export type { DocsService };

--- a/src/browser/services/selected.ts
+++ b/src/browser/services/selected.ts
@@ -22,9 +22,16 @@ export function selected(context: unknown) {
 type File = { default: string | ComponentLike };
 type Loader = () => Promise<File>;
 
+/**
+ * The store `selected(context)` returns.
+ */
 class Selected {
-  @service declare router: RouterService;
+  @service declare private router: RouterService;
 
+  /**
+   * The page-module map — path to document loader.
+   * `setupKolay` fills this in; reading it directly is rarely needed.
+   */
   compiledDocs: Record<string, Loader> = {};
 
   get #docs() {
@@ -47,6 +54,12 @@ class Selected {
     return fn?.();
   });
 
+  /**
+   * The rendered document (a component), if ready.
+   *
+   * While a new page loads (or after it errored), this keeps the
+   * previously rendered page, so navigation doesn't flash an empty screen.
+   */
   get prose() {
     if (this.error) {
       return;
@@ -55,14 +68,23 @@ class Selected {
     return this.doc.prose;
   }
 
+  /**
+   * Has the current page finished loading and compiling?
+   */
   get isReady() {
     return this.doc.isReady;
   }
 
+  /**
+   * Is the current page still loading / compiling?
+   */
   get isPending() {
     return !this.isReady;
   }
 
+  /**
+   * Did resolving the page, loading, or compiling fail?
+   */
   get hasError() {
     if (this.error) {
       return Boolean(this.error);
@@ -71,6 +93,9 @@ class Selected {
     return this.doc.hasError;
   }
 
+  /**
+   * A human-readable error message; `''` when there is none.
+   */
   @cached
   get error() {
     if (!this.#page) {
@@ -90,6 +115,9 @@ class Selected {
     return error;
   }
 
+  /**
+   * `Boolean(this.prose)`
+   */
   get hasProse() {
     return Boolean(this.prose);
   }
@@ -147,3 +175,5 @@ class Selected {
     console.groupEnd();
   }
 }
+
+export type { Selected };

--- a/src/browser/typedoc/renderer.gts
+++ b/src/browser/typedoc/renderer.gts
@@ -161,6 +161,11 @@ const Declaration: TOC<{
         <div class='typedoc__declaration-type'>
           <Type @info={{@info.type}} />
         </div>
+      {{else if @info.getSignature.type}}
+        {{! accessors keep their type on the get signature }}
+        <div class='typedoc__declaration-type'>
+          <Type @info={{@info.getSignature.type}} />
+        </div>
       {{/if}}
 
       {{#if @info.children}}
@@ -183,6 +188,9 @@ const Declaration: TOC<{
       {{#if (not (isConst @info))}}
         {{#if @info.comment.summary}}
           <Comment @info={{@info}} />
+        {{else if @info.getSignature.comment.summary}}
+          {{! accessors keep their comment on the get signature }}
+          <Comment @info={{@info.getSignature}} />
         {{/if}}
       {{/if}}
     </div>


### PR DESCRIPTION
Runtime → Utilities → `docsManager(...)` described a handful of members in a code comment but never showed the store's actual API.

- `DocsService` is exported (type-only) from `kolay` and rendered on the page via `<APIDocs @name="DocsService" />`.
- Public members have doc comments (`selectedGroup`'s old internal musing rewritten as user-facing docs); `router`, `_docs`, and the `docs` getter are `private`; the never-used `loadManifest` field is removed; `[PREPARE_DOCS]` carries `@private` so typedoc excludes it while test-support keeps runtime access.
- Test: visits the page and asserts the section, all 13 public members, and that `PREPARE_DOCS` stays hidden. docs-app 49/49, lint 21/21.

Stacked on #338 (shares the accessor-rendering fix and the `Selected` export block); will show only its own diff once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)