### PR TITLE
Rework typedoc rendering CSS: types read like code

### DIFF
--- a/docs-app/src/templates/application.gts
+++ b/docs-app/src/templates/application.gts
@@ -155,39 +155,40 @@ export default Route(
         margin: 0;
       }
 
-      @media (min-width: 768px) {
+      /* One structural breakpoint: the side nav is either in the page
+       * (wide) or in the drawer (narrow). Everything else is fluid. */
+      @media (width >= 768px) {
         .big-layout { display: grid; }
         header button.mobile-menu__toggle {
           display: none;
         }
       }
 
-      @media (max-width: 768px) {
+      @media (width < 768px) {
         .big-layout { display: flex; }
         .big-layout aside { display: none; }
       }
 
-      /* phones: a slimmer page gutter — the group designs carry their
-       * own inner padding */
-      @media (max-width: 640px) {
-        .mobile-menu-wrapper__content.container {
-          padding-inline: 0.6rem;
-        }
-      }
-
       /* The whole viewport is the page: short docs still fill it, so the
-       * groups' full-height designs hold their shape */
+       * groups' full-height designs hold their shape. Width is fluid —
+       * pico's stepped .container max-widths would leave dead margins at
+       * in-between sizes — with one cap for very large screens and a
+       * gutter that scales with the viewport. */
       .mobile-menu-wrapper__content.container {
         min-height: 100dvh;
         display: flex;
         flex-direction: column;
+        width: 100%;
+        max-width: 90rem;
+        margin-inline: auto;
+        padding-inline: clamp(0.6rem, 2.5vw, 2rem);
       }
 
       .big-layout {
         /* fixed nav column: flipping between groups (whose page lists
          * differ in width) must not shift the content */
         grid-template-columns: 16rem 1fr;
-        gap: 2rem;
+        gap: clamp(1rem, 2.5vw, 2rem);
         flex: 1;
 
         main {

--- a/docs-app/src/templates/application.gts
+++ b/docs-app/src/templates/application.gts
@@ -167,6 +167,14 @@ export default Route(
         .big-layout aside { display: none; }
       }
 
+      /* phones: a slimmer page gutter — the group designs carry their
+       * own inner padding */
+      @media (max-width: 640px) {
+        .mobile-menu-wrapper__content.container {
+          padding-inline: 0.6rem;
+        }
+      }
+
       /* The whole viewport is the page: short docs still fill it, so the
        * groups' full-height designs hold their shape */
       .mobile-menu-wrapper__content.container {

--- a/docs-app/src/templates/runtime/page.gjs
+++ b/docs-app/src/templates/runtime/page.gjs
@@ -128,29 +128,13 @@ function hasReason(error) {
       /* the content region fills the space next to the nav, same as
        * every other group — the reading measure is handled inside
        * (see .runtime-doc rules in app.css) */
-      margin: 1.5rem 0 3rem;
-      padding: 2.5rem 3rem 4rem;
+      margin: clamp(0.25rem, 1.5vw, 1.5rem) 0 clamp(1.5rem, 3vw, 3rem);
+      padding: clamp(1rem, 2.5vw, 2.5rem) clamp(0.7rem, 3.5vw, 3rem) clamp(2.5rem, 4vw, 4rem);
       /* the paper: an elevated sheet on the washed page */
       background: var(--pico-card-background-color);
       border: 1px solid color-mix(in oklab, var(--pico-muted-border-color), transparent 40%);
       border-radius: 0.75rem;
       box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
-    }
-
-    @media (max-width: 960px) {
-      .runtime-doc {
-        margin-block: 0.5rem 2rem;
-        padding: 1.5rem 1.25rem 3rem;
-      }
-    }
-
-    /* phones: the sheet inset eats reading width — keep just enough
-     * to still read as a sheet */
-    @media (max-width: 640px) {
-      .runtime-doc {
-        margin-block: 0.25rem 1.5rem;
-        padding: 1rem 0.7rem 2.5rem;
-      }
     }
 
     .guide-eyebrow {

--- a/docs-app/src/templates/runtime/page.gjs
+++ b/docs-app/src/templates/runtime/page.gjs
@@ -144,6 +144,15 @@ function hasReason(error) {
       }
     }
 
+    /* phones: the sheet inset eats reading width — keep just enough
+     * to still read as a sheet */
+    @media (max-width: 640px) {
+      .runtime-doc {
+        margin-block: 0.25rem 1.5rem;
+        padding: 1rem 0.7rem 2.5rem;
+      }
+    }
+
     .guide-eyebrow {
       display: flex;
       align-items: center;

--- a/docs-app/src/templates/typedoc/page.gjs
+++ b/docs-app/src/templates/typedoc/page.gjs
@@ -126,6 +126,13 @@ exit code 1</pre>
       padding: 1.25rem 1.5rem 3rem;
     }
 
+    /* phones: keep the terminal chrome, shrink the inset */
+    @media (max-width: 640px) {
+      .term__body {
+        padding: 1rem 0.7rem 2.5rem;
+      }
+    }
+
     .term__loading,
     .term__error {
       margin: 0;

--- a/docs-app/src/templates/typedoc/page.gjs
+++ b/docs-app/src/templates/typedoc/page.gjs
@@ -123,14 +123,7 @@ exit code 1</pre>
 
     .term__body {
       flex: 1;
-      padding: 1.25rem 1.5rem 3rem;
-    }
-
-    /* phones: keep the terminal chrome, shrink the inset */
-    @media (max-width: 640px) {
-      .term__body {
-        padding: 1rem 0.7rem 2.5rem;
-      }
+      padding: clamp(1rem, 2vw, 1.25rem) clamp(0.7rem, 2vw, 1.5rem) 3rem;
     }
 
     .term__loading,

--- a/docs-app/tests/docs-app/runtime-nav-test.gts
+++ b/docs-app/tests/docs-app/runtime-nav-test.gts
@@ -112,7 +112,9 @@ module('Runtime docs navigation', function (hooks) {
     assert.dom('[data-page-error]').doesNotExist();
 
     const labels = [
-      ...document.querySelectorAll('.runtime-doc :is(h1, h2, h3, .typedoc__declaration-name)'),
+      ...document.querySelectorAll(
+        '.runtime-doc h1, .runtime-doc h2, .runtime-doc h3, .runtime-doc .typedoc__declaration-name'
+      ),
     ]
       .map((el) => el.textContent?.trim())
       .filter((text) => text === 'DocsService');

--- a/docs-app/tests/docs-app/runtime-nav-test.gts
+++ b/docs-app/tests/docs-app/runtime-nav-test.gts
@@ -51,11 +51,11 @@ module('Runtime docs navigation', function (hooks) {
 
     assert.dom('[data-page-error]').doesNotExist();
 
-    const section = [...document.querySelectorAll('h3')].find((h3) =>
-      h3.textContent?.includes('CompileState')
+    const label = [...document.querySelectorAll('.typedoc__declaration-name')].find(
+      (name) => name.textContent?.trim() === 'CompileState'
     );
 
-    assert.ok(section, 'the CompileState section exists');
+    assert.ok(label, 'CompileState renders, labeled once by the declaration');
 
     for (const field of ['component', 'error', 'isReady', 'promise', 'reason']) {
       assert.dom('.runtime-doc').containsText(field);
@@ -86,11 +86,11 @@ module('Runtime docs navigation', function (hooks) {
 
     assert.dom('[data-page-error]').doesNotExist();
 
-    const section = [...document.querySelectorAll('h3')].find((h3) =>
-      h3.textContent?.includes('Selected')
+    const label = [...document.querySelectorAll('.typedoc__declaration-name')].find(
+      (name) => name.textContent?.trim() === 'Selected'
     );
 
-    assert.ok(section, 'the Selected section exists');
+    assert.ok(label, 'Selected renders, labeled once by the declaration');
 
     for (const member of ['doc', 'prose', 'isReady', 'isPending', 'hasError', 'error']) {
       assert.dom('.runtime-doc').containsText(member);
@@ -111,11 +111,13 @@ module('Runtime docs navigation', function (hooks) {
 
     assert.dom('[data-page-error]').doesNotExist();
 
-    const section = [...document.querySelectorAll('h3')].find((h3) =>
-      h3.textContent?.includes('DocsService')
-    );
+    const labels = [
+      ...document.querySelectorAll('.runtime-doc :is(h1, h2, h3, .typedoc__declaration-name)'),
+    ]
+      .map((el) => el.textContent?.trim())
+      .filter((text) => text === 'DocsService');
 
-    assert.ok(section, 'the DocsService section exists');
+    assert.deepEqual(labels, ['DocsService'], 'DocsService is labeled exactly once');
 
     for (const member of [
       'manifest',

--- a/docs/rendering/compiled.gjs.md
+++ b/docs/rendering/compiled.gjs.md
@@ -45,8 +45,6 @@ const doc = `Hello from **a string**!`;
 
 <APIDocs @module="declarations/browser" @name="Compiled" @package="kolay" />
 
-### `CompileState`
-
-The state `Compiled` gives back is [ember-repl](/ecosystem/ember-repl)'s `CompileState`:
+The state `Compiled` gives back is defined by [ember-repl](/ecosystem/ember-repl):
 
 <APIDocs @module="declarations" @name="CompileState" @package="ember-repl" />

--- a/docs/utilities/docs-manager.gjs.md
+++ b/docs/utilities/docs-manager.gjs.md
@@ -31,8 +31,6 @@ At the default `rootURL` of `/`, the two are identical.
 
 <APIDocs @module="declarations/browser" @name="docsManager" @package="kolay" />
 
-### `DocsService`
-
 The store `docsManager` returns:
 
 <APIDocs @module="declarations/browser" @name="DocsService" @package="kolay" />

--- a/docs/utilities/selected.gjs.md
+++ b/docs/utilities/selected.gjs.md
@@ -54,8 +54,6 @@ To render a document that is _not_ the current page (something you fetched yours
 
 <APIDocs @module="declarations/browser" @name="selected" @package="kolay" />
 
-### `Selected`
-
 The store `selected` returns:
 
 <APIDocs @module="declarations/browser" @name="Selected" @package="kolay" />

--- a/src/browser/typedoc/renderer.gts
+++ b/src/browser/typedoc/renderer.gts
@@ -399,7 +399,11 @@ export const Type: TOC<{ Args: { info: SomeType } }> = <template>
   <Consume @key='project' as |project|>
     {{#let (getComponentSignature @info.declaration project) as |maybe|}}
       {{#if maybe}}
-        <ComponentDeclaration @signature={{maybe}} />
+        {{! a component signature in a type position renders compactly —
+            the class scopes the code-like styling }}
+        <span class='typedoc__nested-signature'>
+          <ComponentDeclaration @signature={{maybe}} />
+        </span>
       {{else if (isReference @info)}}
         {{! @glint-expect-error }}
         <Reference @info={{@info}} />

--- a/src/browser/typedoc/styles.css
+++ b/src/browser/typedoc/styles.css
@@ -206,6 +206,26 @@ section {
     padding-left: 0.25rem;
     padding-right: 0;
   }
+
+  ul.typedoc__declaration-children {
+    padding-left: 0.5rem;
+  }
+
+  .typedoc__nested-signature {
+    margin-left: 0.1rem;
+    padding-left: 0.5rem;
+  }
+
+  :is(
+      .typedoc__declaration-type,
+      .typedoc__reference__typeArgument,
+      .typedoc__nested-signature,
+      .typedoc__property
+    )
+    .typedoc__declaration
+    .typedoc-rendered-comment {
+    margin-left: 0.5rem;
+  }
 }
 
 /* ---------------------------------------------------------------- *

--- a/src/browser/typedoc/styles.css
+++ b/src/browser/typedoc/styles.css
@@ -1,29 +1,58 @@
+/*
+ * Reading model:
+ *
+ * - Member ROWS (a class/interface's members, a signature's args): name on
+ *   the left, type chip on the right, comment as prose beneath.
+ *
+ * - TYPE POSITIONS (everything to the right of a `:`): read like code —
+ *   references inline (`Name<Arg>`), unions inline (`a | b`), functions as
+ *   `(name: Type) => Return`, object shapes as indented `name: type` lines.
+ *   A component signature appearing inside a type (`ComponentLike<{...}>`)
+ *   compacts to the same code-ish look (`.typedoc__nested-signature`).
+ *
+ * All borders derive from currentColor so both themes work.
+ */
+
+/* ---------------------------------------------------------------- *
+ * Leaf tokens (chips)
+ * ---------------------------------------------------------------- */
+
 .typedoc__type-link,
 .typedoc__unknown__yield,
-.typedoc__intrinsic {
-  border: 1px solid #222;
-  display: inline-block;
-  font-style: italic;
-  font-family: monospace;
+.typedoc__intrinsic,
+.typedoc__reference__name,
+.typedoc__literal {
+  display: inline;
+  width: fit-content;
+  border: 1px solid color-mix(in oklab, currentColor 30%, transparent);
+  border-radius: 0.25rem;
+  background: color-mix(in oklab, currentColor 6%, transparent);
+  font-style: normal;
+  font-family: var(--pico-font-family-monospace, monospace);
+  font-size: 0.8em;
   margin: 0;
-  font-size: 0.75rem;
-  padding: 0 0.5rem;
+  padding: 0.05em 0.4em;
 }
 
-.typedoc__type-link {
-  padding: 0 0.5rem;
+.typedoc__unknown {
+  display: inline;
+  font-family: var(--pico-font-family-monospace, monospace);
 }
+
+/* ---------------------------------------------------------------- *
+ * Member rows
+ * ---------------------------------------------------------------- */
 
 .typedoc__declaration-name {
   margin: 0;
   display: inline-block;
   line-height: 1.5rem;
+  font-weight: bold;
 }
 
 .typedoc__declaration {
   display: grid;
   gap: 1rem;
-  display: grid;
   grid-template-columns: max-content 1fr max-content;
   grid-template-areas:
     "name . type"
@@ -33,8 +62,7 @@
     grid-area: name;
   }
 
-  .typedoc__declaration-type,
-  .typedoc__declararation-children {
+  .typedoc__declaration-type {
     grid-area: type;
   }
 
@@ -51,8 +79,23 @@
   }
 }
 
-.typedoc__declaration-name {
-  font-weight: bold;
+/* A member whose type is a multi-line shape (an object type, a nested
+ * component signature): the far-right column would orphan it — stack
+ * `name:` above the indented shape instead, like source code. */
+.typedoc__declaration:has(
+  > .typedoc__declaration-type :is(ul.typedoc__declaration-children, .typedoc__nested-signature)
+) {
+  display: block;
+
+  > .typedoc__declaration-name::after {
+    content: ":";
+    font-weight: normal;
+  }
+
+  > .typedoc__declaration-type {
+    display: block;
+    margin: 0.25rem 0 0.5rem;
+  }
 }
 
 section {
@@ -71,7 +114,278 @@ section {
   padding: 0 1rem;
   display: flex;
   flex-direction: column;
+  align-items: stretch;
 }
+
+.typedoc__declaration-signatures {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  > li {
+    list-style: none;
+    border-bottom: 1px dashed color-mix(in oklab, currentColor 25%, transparent);
+  }
+}
+
+/* a function type inside a type position flows inline with the
+ * expression around it (e.g. inside a union) */
+:is(
+    .typedoc__declaration-type,
+    .typedoc__reference__typeArgument,
+    .typedoc__union__type,
+    .typedoc__function__parameter__type,
+    .typedoc__function__return_type
+  )
+  .typedoc__declaration:has(> .typedoc__declaration-signatures) {
+  display: inline;
+  padding: 0;
+
+  > .typedoc__declaration-signatures {
+    display: inline;
+
+    > li {
+      display: inline;
+      border: none;
+    }
+  }
+}
+
+/* member lists at row level: one member per row, separated */
+.typedoc__declaration-children,
+.typedoc__declaration-children li {
+  list-style: none;
+  padding: 0 0.5rem;
+}
+
+.typedoc__declaration-children li {
+  border-bottom: 1px dashed color-mix(in oklab, currentColor 25%, transparent);
+}
+
+/* ---------------------------------------------------------------- *
+ * Type positions: code-like flow
+ * ---------------------------------------------------------------- */
+
+/* nested declarations become `name: type` code lines */
+:is(
+    .typedoc__declaration-type,
+    .typedoc__reference__typeArgument,
+    .typedoc__union__type,
+    .typedoc__function__parameter__type,
+    .typedoc__function__return_type,
+    .typedoc__array,
+    .typedoc__nested-signature,
+    .typedoc__property
+  )
+  .typedoc__declaration {
+  display: block;
+  grid-template-columns: unset;
+  grid-template-areas: unset;
+  gap: 0;
+  padding: 0.1rem 0;
+
+  > .typedoc__declaration-name {
+    font-size: inherit;
+    font-weight: 600;
+    font-family: var(--pico-font-family-monospace, monospace);
+    line-height: inherit;
+
+    &::after {
+      content: ": ";
+      font-weight: normal;
+    }
+  }
+
+  > .typedoc__declaration-type {
+    display: inline;
+    margin: 0 0 0 0.25rem;
+  }
+}
+
+/* nested object shapes: indented member lines behind a soft rule */
+:is(
+    .typedoc__declaration-type,
+    .typedoc__reference__typeArgument,
+    .typedoc__union__type,
+    .typedoc__function__parameter__type,
+    .typedoc__function__return_type,
+    .typedoc__nested-signature,
+    .typedoc__property
+  )
+  ul.typedoc__declaration-children {
+  display: block;
+  margin: 0 0 0 0.25rem;
+  padding: 0 0 0 0.9rem;
+  border-left: 2px solid color-mix(in oklab, currentColor 15%, transparent);
+
+  > li {
+    list-style: none;
+    border: none;
+    padding: 0.05rem 0;
+  }
+}
+
+/* comments inside a type shape: muted prose under the member they describe */
+:is(
+    .typedoc__declaration-type,
+    .typedoc__reference__typeArgument,
+    .typedoc__nested-signature,
+    .typedoc__property
+  )
+  .typedoc__declaration
+  .typedoc-rendered-comment {
+  font-size: 0.85em;
+  color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+  margin: 0.1rem 0 0.4rem 0.9rem;
+
+  :is(p, pre) {
+    margin: 0.15rem 0;
+  }
+}
+
+/* ---------------------------------------------------------------- *
+ * References: Name<Arg, Arg> inline
+ * ---------------------------------------------------------------- */
+
+.typedoc__reference,
+.typedoc__reference:has(.typedoc__reference__typeArguments),
+.typedoc__reference__typeArguments,
+.typedoc__reference__typeArgument {
+  display: inline;
+  width: auto;
+}
+
+.typedoc__reference__typeArgument + .typedoc__reference__typeArgument::before {
+  content: ", ";
+}
+
+/* ---------------------------------------------------------------- *
+ * Arrays
+ * ---------------------------------------------------------------- */
+
+.typedoc__array,
+.typedoc__array__indicator {
+  display: inline;
+}
+
+.typedoc__array__indicator {
+  font-style: italic;
+  margin-right: 0.25rem;
+}
+
+/* ---------------------------------------------------------------- *
+ * Functions: (name: Type, ...) => Return
+ * ---------------------------------------------------------------- */
+
+.typedoc__function,
+.typedoc__function__type,
+.typedoc__function__parameters,
+.typedoc__function__parameter__container,
+.typedoc__function__parameter,
+.typedoc__function__parameter__type,
+.typedoc__function__open,
+.typedoc__function__close,
+.typedoc__function__return_type {
+  display: inline;
+}
+
+.typedoc__function__parameter__container + .typedoc__function__parameter__container::before {
+  content: ", ";
+}
+
+.typedoc__function__close {
+  margin: 0 0.25rem;
+}
+
+.typedoc__function__parameter__name {
+  display: inline;
+  font-style: normal;
+  font-family: var(--pico-font-family-monospace, monospace);
+  font-size: 0.9em;
+  font-weight: 600;
+
+  &::after {
+    content: ": ";
+    font-weight: normal;
+  }
+}
+
+/* a parameter with docs gets its own line, like a formatted long signature */
+.typedoc__function__parameter__container:has(.typedoc-rendered-comment) {
+  display: block;
+  margin-left: 1.5rem;
+
+  .typedoc-rendered-comment {
+    font-size: 0.85em;
+    color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+    margin: 0.1rem 0 0.4rem 0.9rem;
+
+    :is(p, pre) {
+      margin: 0.15rem 0;
+    }
+  }
+}
+
+.typedoc__function__parameter__comment {
+  display: inline;
+}
+
+/* the wrapper is always rendered — only give it room when a comment
+ * actually rendered, so empty ones don't break inline signatures */
+.typedoc__function_comment {
+  display: inline;
+}
+
+.typedoc__function_comment:has(.typedoc-rendered-comment) {
+  display: block;
+}
+
+/* ---------------------------------------------------------------- *
+ * Literals & unions
+ * ---------------------------------------------------------------- */
+
+.typedoc__literal {
+  font-family: var(--pico-font-family-monospace, monospace);
+}
+
+.typedoc__union,
+.typedoc__union__type {
+  display: inline;
+}
+
+.typedoc__union__type::before {
+  content: "| ";
+}
+
+.typedoc__union .typedoc__union__type:first-child::before {
+  content: none;
+}
+
+/* ---------------------------------------------------------------- *
+ * Argument flags
+ * ---------------------------------------------------------------- */
+
+.typedoc__arg-flags {
+  display: flex;
+  gap: 0.25rem;
+  align-items: baseline;
+  justify-content: flex-start;
+  margin: 0.5rem 0;
+}
+
+.typedoc__arg-flags > .typedoc__flag {
+  display: inline-block;
+  margin: 0;
+  font-size: 0.75rem;
+  padding: 0 0.5rem;
+  border: 1px solid color-mix(in oklab, currentColor 30%, transparent);
+  border-radius: var(--pico-border-radius);
+  font-family: var(--pico-font-family-monospace, monospace);
+}
+
+/* ---------------------------------------------------------------- *
+ * Component / modifier / helper signatures (top level)
+ * ---------------------------------------------------------------- */
 
 .typedoc__modifier-signature__arg,
 .typedoc__helper-signature__arg,
@@ -84,15 +398,6 @@ section {
     "comment";
 }
 
-.typedoc__declaration-signatures {
-  list-style: none;
-
-  > li {
-    border-bottom: 1px dashed color-mix(in lch, currentColor 50%, transparent 75%);
-  }
-}
-
-.typedoc__named-tuple,
 .typedoc__component-signature__arg-info,
 .typedoc__helper-signature__arg-info,
 .typedoc__modifier-signature__arg-info {
@@ -100,6 +405,24 @@ section {
   gap: 0.25rem;
   align-items: baseline;
   justify-content: space-between;
+}
+
+/* named tuple members read like code: `name: type` */
+.typedoc__named-tuple {
+  display: inline;
+
+  > .typedoc__name {
+    display: inline;
+    margin: 0;
+    font-family: var(--pico-font-family-monospace, monospace);
+    font-weight: 600;
+    font-size: inherit;
+
+    &::after {
+      content: ": ";
+      font-weight: normal;
+    }
+  }
 }
 
 .typedoc__component-signature__arg-info > .typedoc__name,
@@ -114,7 +437,7 @@ section {
 .typedoc__component-signature__arg-info,
 .typedoc__modifier-signature__arg-info,
 .typedoc__helper-signature__arg-info {
-  border-bottom: 1px rgba(125, 125, 125, 0.5) dashed;
+  border-bottom: 1px dashed color-mix(in oklab, currentColor 25%, transparent);
   grid-area: info;
   display: flex;
   justify-content: space-between;
@@ -130,42 +453,6 @@ section {
   margin: 0;
 }
 
-.typedoc__declaration-children,
-.typedoc__declaration-children li {
-  list-style: none;
-  padding: 0 0.5rem;
-}
-
-.typedoc__declaration-children li {
-  border-bottom: 1px rgba(125, 125, 125, 0.5) dashed;
-}
-
-/**
- * Argument Flags
- */
-.typedoc__arg-flags {
-  display: flex;
-  gap: 0.25rem;
-  align-items: baseline;
-  justify-content: flex-start;
-  margin: 0.5rem 0;
-}
-
-.typedoc__arg-flags > .typedoc__flag {
-  display: inline-block;
-  margin: 0;
-  font-size: 0.75rem;
-  padding: 0 0.5rem;
-  border: 1px solid #222;
-  border-radius: var(--pico-border-radius);
-  font-family: var(--pico-font-family-monospace);
-}
-
-/**
- *
- * Component Signatures
- *
- */
 .typedoc__modifier-signature__element,
 .typedoc__component-signature__element,
 .typedoc__component-signature__block {
@@ -173,12 +460,13 @@ section {
   padding: 0 1rem;
 }
 
+/* the element's name and its type link sit together, not pushed apart */
 .typedoc__modifier-signature__element-type,
 .typedoc__component-signature__element-type {
   display: flex;
-  gap: 0.25rem;
+  gap: 0.5rem;
   align-items: baseline;
-  justify-content: space-between;
+  justify-content: flex-start;
 }
 
 .typedoc__modifier-signature__element-type > .typedoc__name,
@@ -193,13 +481,16 @@ section {
   display: flex;
   flex-direction: row;
   width: 100%;
-  justify-content: space-between;
+  gap: 0.75rem;
   align-items: baseline;
 }
 
-.typedoc__helper-signature__block .typedoc-rendered-comment,
-.typedoc__component-signature__block .typedoc-rendered-comment {
-  border-top: 1px solid #333;
+/* only the block's own comment gets the separating rule — member
+ * comments deeper inside keep the muted inline treatment */
+.typedoc__helper-signature__block > .typedoc-rendered-comment,
+.typedoc__helper-signature__block > * > .typedoc-rendered-comment,
+.typedoc__component-signature__block > .typedoc__property > .typedoc-rendered-comment {
+  border-top: 1px solid color-mix(in oklab, currentColor 20%, transparent);
   padding-top: 0.5rem;
   margin-top: 0.5rem;
 }
@@ -209,22 +500,7 @@ section {
 }
 
 .typedoc__component-signature__block > .typedoc__property {
-  border-left: 1px dashed color-mix(in lch, currentColor 50%, transparent 75%);
-}
-
-.typedoc__component-signature__block > .typedoc__property .typedoc__declaration-children {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.typedoc__component-signature__block
-  > .typedoc__property
-  > .typedoc__declaration
-  > ul.typedoc__declaration-children
-  > li:not(:last-child)
-  > .typedoc__declaration {
-  border-bottom: 1px solid lightgray;
-  padding: 0.5rem;
+  border-left: 1px dashed color-mix(in oklab, currentColor 25%, transparent);
 }
 
 .typedoc__helper-signature__arg,
@@ -240,8 +516,6 @@ section {
 .typedoc__component-signature__arg > .typedoc__name,
 .typedoc__component-signature__block > .typedoc__name {
   font-size: 1.2rem;
-  overflow-y: hidden;
-  overflow-x: hidden;
   overflow: hidden;
   margin: 0;
   max-height: unset;
@@ -254,131 +528,89 @@ section {
   margin-bottom: 0.25rem;
 }
 
-/**
- * References
- */
-.typedoc__reference:has(.typedoc__reference__typeArguments) {
-  display: grid;
-  grid-auto-flow: row;
+/* ---------------------------------------------------------------- *
+ * Component signatures inside a type position: compact
+ * ---------------------------------------------------------------- */
+
+.typedoc__nested-signature {
+  display: block;
+  margin: 0.15rem 0 0.15rem 0.25rem;
+  padding-left: 0.9rem;
+  border-left: 2px solid color-mix(in oklab, currentColor 15%, transparent);
+
+  section {
+    margin: 0;
+    padding: 0;
+  }
+
+  /* "Element" / "Arguments" / "Blocks" become small labels, not headings */
+  .typedoc__heading {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+    margin: 0.5rem 0 0.15rem;
+  }
+
+  /* the element label and its type link share a line */
+  .typedoc__heading:is(
+    .typedoc__component-signature__element-header,
+    .typedoc__modifier-signature__element-header
+  ) {
+    display: flex;
+    gap: 0.75rem;
+    align-items: baseline;
+  }
+
+  .typedoc__heading :is(.typedoc__type-link, .typedoc__name) {
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: 0.9rem;
+  }
+
+  /* block names (<:default>) are plain code text, not banded pre blocks */
+  pre.typedoc__name {
+    display: inline-block;
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    font-size: 0.9em;
+  }
+
+  .typedoc__component-signature__element,
+  .typedoc__component-signature__block,
+  .typedoc__component-signature__arg,
+  .typedoc__modifier-signature__element,
+  .typedoc__modifier-signature__arg,
+  .typedoc__helper-signature__arg {
+    display: block;
+    padding: 0;
+    margin: 0;
+  }
+
+  .typedoc__property {
+    padding: 0 0 0 0.9rem;
+    border: none;
+  }
+
+  .typedoc__component-signature__block .typedoc-rendered-comment {
+    border-top: none;
+    padding-top: 0;
+    margin: 0.1rem 0 0.4rem 0.9rem;
+    font-size: 0.85em;
+    color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+  }
 }
 
-.typedoc__reference__name {
-  display: inline;
-  border: 1px solid #222;
-  font-style: italic;
-  font-family: monospace;
-  margin: 0;
-  font-size: 0.75rem;
-  padding: 0 0.5rem;
-}
+/* ---------------------------------------------------------------- *
+ * Union variants (discriminated union signatures)
+ * ---------------------------------------------------------------- */
 
-.typedoc__reference__typeArguments {
-  display: inline-grid;
-  width: fit-content;
-  grid-auto-flow: column;
-  gap: 0.5rem;
-}
-
-.typedoc__reference__typeArgument {
-  /* border: 1px solid; */
-}
-
-/**
- * Array formatting
- */
-.typedoc__array > div.typedoc__declaration > ul.typedoc__declaration-children {
-  border: 1px solid;
-  margin: 0;
-}
-
-/**
- * Signature / Function Formatting
- */
-.typedoc__function__type {
-  display: flex;
-  align-items: start;
-  gap: 0.25rem;
-}
-
-.typedoc__function__type:has(.typedoc__function__parameter) {
-  /* display: grid; */
-}
-
-.typedoc__function__parameters {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.typedoc__function__parameter__container {
-  border: 1px dashed color-mix(in lch, currentColor 50%, transparent 75%);
-  padding: 0.5rem;
-}
-
-.typedoc__function__parameter {
-  width: fit-content;
-  display: grid;
-  grid-auto-flow: column;
-  gap: 0.5rem;
-}
-
-.typedoc__function__parameter__comment {
-  /* font-style: italic; */
-  /* font-size: 0.75rem; */
-}
-
-.typedoc__function__open,
-.typedoc__function__close {
-  display: ruby;
-}
-
-.typedoc__function__return_type {
-  display: inline-block;
-}
-
-.typedoc__function__return_type {
-}
-
-.typedoc__function__parameter__name {
-  font-style: italic;
-  font-family: monospace;
-  font-size: 1rem;
-}
-
-/**
- * Literal
- */
-.typedoc__literal {
-  font-family: monospace;
-  font-size: 0.75rem;
-}
-
-/**
- * Union
- */
-.typedoc__union {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-}
-
-.typedoc__union__type {
-  display: inline-flex;
-  gap: 0.25rem;
-}
-
-.typedoc__union__type::before {
-  content: "|";
-}
-
-.typedoc__union .typedoc__union__type:first-child::before {
-  display: none;
-}
-
-/**
- * Union Variant (discriminated union signatures)
- */
 .typedoc__union-variant + .typedoc__union-variant {
   margin-top: 1.5rem;
   padding-top: 1.5rem;
-  border-top: 1px solid light-dark(#e4e4e7, #3f3f46);
+  border-top: 1px solid color-mix(in oklab, currentColor 20%, transparent);
 }

--- a/src/browser/typedoc/styles.css
+++ b/src/browser/typedoc/styles.css
@@ -162,6 +162,52 @@ section {
   border-bottom: 1px dashed color-mix(in oklab, currentColor 25%, transparent);
 }
 
+/* narrow screens: the side-by-side row (and the far-right max-content
+ * type column, which cannot wrap) would squeeze or clip signatures —
+ * stack each row: name, then type (wrapping), then comment */
+@media (max-width: 40rem) {
+  .typedoc__declaration {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "name"
+      "type"
+      "comment";
+    gap: 0.25rem;
+
+    > * {
+      min-width: 0;
+    }
+
+    > .typedoc__declaration-type {
+      justify-self: start;
+    }
+
+    &:has(> .typedoc__declaration-signatures) {
+      grid-auto-flow: row;
+    }
+  }
+
+  section {
+    > .typedoc__declaration {
+      > .typedoc__declaration-name {
+        font-size: 1.25rem;
+      }
+    }
+  }
+
+  /* indentation is precious at 390px */
+  .typedoc__property,
+  .typedoc__modifier-signature__arg,
+  .typedoc__helper-signature__arg,
+  .typedoc__component-signature__arg,
+  .typedoc__modifier-signature__element,
+  .typedoc__component-signature__element,
+  .typedoc__component-signature__block {
+    padding-left: 0.25rem;
+    padding-right: 0;
+  }
+}
+
 /* ---------------------------------------------------------------- *
  * Type positions: code-like flow
  * ---------------------------------------------------------------- */

--- a/src/browser/typedoc/styles.css
+++ b/src/browser/typedoc/styles.css
@@ -98,6 +98,13 @@
   }
 }
 
+/* a declaration that is a member list (a class, an interface): the
+ * side-by-side grid would spend a whole column on the name — the name
+ * is a heading line, members span the full width below it */
+.typedoc__declaration:has(> ul.typedoc__declaration-children) {
+  display: block;
+}
+
 section {
   > .typedoc__declaration {
     > .typedoc__declaration-name {


### PR DESCRIPTION
The renderers with nested or complex types made the CSS issues obvious: every nesting level reused the name-left/type-far-right grid, so `ComponentLike<{Element, Blocks}>` inside a yield exploded into orphaned columns, floating `<`/`>` glyphs, full-width-stretched chips, and comments separated from the members they describe by wide rules and dead space.

New reading model (documented at the top of `styles.css`):

- **Member rows** (a class's members, a signature's args) keep the tabular name-left / type-chip-right look. A member whose type is a multi-line shape stacks `name:` above the indented shape instead of orphaning it in the far-right column.
- **Type positions** (everything right of a `:`) read like code: references inline (`Name<Arg, Arg>`), unions inline (`a | b`), functions as `(name: Type) => Return` on one line (a parameter with docs gets its own line), object shapes as indented `name: type` lines behind a soft left rule, named tuples as `name: type`. Comments inside a shape render as muted prose directly under their member.
- A component signature in a type position renders compactly via a new `.typedoc__nested-signature` wrapper (one markup change in `renderer.gts`): Element/Blocks headings become small uppercase labels, `<:block>` names plain code text.
- Every hardcoded `#222`/`#333`/`lightgray` border is now `color-mix(... currentColor ...)`, so the dark theme stops getting light-mode borders.

Concrete before/after (docs-app):
- `groupFor` on Runtime → Utilities → docsManager: was a spread of dashed boxes with `list/name/tree` floating far right; now `( groupName: string | undefined ) =>` with the returned shape indented beneath.
- `Compiled` on Runtime → Rendering: was a two-row fragmented union with stray bullets; now `( textFn: string | ( ) => string | null | null ) => CompileState` on one line.
- `<PageNav />`'s `:collection` yield: the nested `ComponentLike` no longer renders giant Element/Blocks headings mid-type.

Verified at 1920×1080 across Runtime (guide design) and TypeDoc (terminal design) pages. docs-app 49/49, lint 21/21.

Stacked on #339 (needs its `Selected`/`DocsService` pages for the worst-case renders); will show only its own diff once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)