### PR TITLE
Side nav collapses at 1000px

### DIFF
--- a/docs-app/src/templates/application.gts
+++ b/docs-app/src/templates/application.gts
@@ -171,14 +171,14 @@ export default Route(
 
       /* One structural breakpoint: the side nav is either in the page
        * (wide) or in the drawer (narrow). Everything else is fluid. */
-      @media (width >= 768px) {
+      @media (width >= 1000px) {
         .big-layout { display: grid; }
         header button.mobile-menu__toggle {
           display: none;
         }
       }
 
-      @media (width < 768px) {
+      @media (width < 1000px) {
         .big-layout { display: flex; }
         .big-layout aside { display: none; }
       }


### PR DESCRIPTION
The structural breakpoint (side nav in the page vs. in the drawer, content full width) moves from 768px to 1000px.

Verified at 966 (drawer + full-width content) and 1024 (side nav present). docs-app 50/50, lint 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)