### PR TITLE
Color the typedoc renderer via CSS variables; document customizing

### DIFF
--- a/docs-app/tests/docs-app/home-nav-test.gts
+++ b/docs-app/tests/docs-app/home-nav-test.gts
@@ -59,6 +59,7 @@ module('Home docs navigation', function (hooks) {
       ['/ecosystem/ember-primitives', 'ember-primitives'],
       ['/ecosystem/ember-repl', 'ember-repl'],
       ['/ecosystem/ember-mobile-menu', 'ember-mobile-menu'],
+      ['/TypeDoc/customizing/rendering', 'Customizing rendering'],
     ]) {
       await visit(url as string);
 

--- a/docs-typedoc/customizing/rendering.gjs.md
+++ b/docs-typedoc/customizing/rendering.gjs.md
@@ -1,0 +1,53 @@
+# Customizing rendering
+
+Everything the api-docs components render is plain HTML with stable `typedoc__*` class names, colored through a small set of CSS variables. Restyling is entirely your app's CSS — there is no kolay configuration involved.
+
+## Colors
+
+Names, types, parameters, and structure each get their own color, so a signature scans like highlighted code. Each is a CSS variable — set them on `:root` (or any ancestor of the rendered docs) to retheme:
+
+| variable | colors | default (light · dark) |
+| --- | --- | --- |
+| `--kolay-typedoc-name` | member & declaration names | `#0550ae` · `#79c0ff` |
+| `--kolay-typedoc-type` | type references (classes, interfaces, components) | `#6639ba` · `#d2a8ff` |
+| `--kolay-typedoc-builtin` | intrinsics & literals (`string`, `number`, `"value"`) | `#116329` · `#7ee787` |
+| `--kolay-typedoc-param` | function parameter names | `#953800` · `#ffa657` |
+| `--kolay-typedoc-punctuation` | structure — `:` `( ) =>` `\|` `< >` | `#59636e` · `#9198a1` |
+| `--kolay-typedoc-comment` | doc comments inside type shapes | your `--pico-muted-color`, else muted text |
+
+The defaults are `light-dark()` aware, following your page's `color-scheme`. Chip borders and backgrounds derive from `currentColor`, so they tint along with whatever colors you choose.
+
+Variables scope like any CSS — set them inline to retheme one rendering (here, `isActive` from this site's own api docs):
+
+```html
+<div style="--kolay-typedoc-name: mediumvioletred; --kolay-typedoc-param: rebeccapurple; --kolay-typedoc-builtin: teal">
+  <APIDocs @package="kolay" @module="declarations/browser" @name="isActive" />
+</div>
+```
+
+<div style="--kolay-typedoc-name: mediumvioletred; --kolay-typedoc-param: rebeccapurple; --kolay-typedoc-builtin: teal">
+  <APIDocs @package="kolay" @module="declarations/browser" @name="isActive" />
+</div>
+
+## Beyond colors
+
+The markup itself is fair game — every element carries a `typedoc__*` class. The layout follows one reading model:
+
+- **Member rows** (a class's members, a signature's args): name on the left, type on the right, comment beneath. Below `40rem` they stack.
+- **Type positions** (everything right of a `:`): code-like flow — `Name<Arg>`, `a | b`, `(name: Type) => Return`, object shapes as indented `name: type` lines.
+
+A few useful hooks:
+
+```css
+/* the root declaration's name (rendered as a heading line) */
+section > .typedoc__declaration > .typedoc__declaration-name {
+  font-size: 1.5rem;
+}
+
+/* square chips instead of rounded */
+.typedoc__intrinsic,
+.typedoc__literal,
+.typedoc__reference__name {
+  border-radius: 0;
+}
+```

--- a/docs-typedoc/meta.json
+++ b/docs-typedoc/meta.json
@@ -1,0 +1,3 @@
+{
+  "order": ["components", "plugin", "customizing"]
+}

--- a/src/browser/typedoc/styles.css
+++ b/src/browser/typedoc/styles.css
@@ -1,4 +1,15 @@
 /*
+ * Colors — override via these variables (set them on :root or any
+ * ancestor). Defaults are light-dark() aware. Chip borders and
+ * backgrounds derive from currentColor, so they tint automatically.
+ *
+ *   --kolay-typedoc-name         member & declaration names
+ *   --kolay-typedoc-type         type references (classes, interfaces, components)
+ *   --kolay-typedoc-builtin      intrinsics & literals (string, number, "value")
+ *   --kolay-typedoc-param        function parameter names
+ *   --kolay-typedoc-punctuation  structure (: ( ) => | < > ,)
+ *   --kolay-typedoc-comment      doc comments rendered inside type shapes
+ *
  * Reading model:
  *
  * - Member ROWS (a class/interface's members, a signature's args): name on
@@ -16,6 +27,16 @@
 /* ---------------------------------------------------------------- *
  * Leaf tokens (chips)
  * ---------------------------------------------------------------- */
+
+.typedoc__reference__name {
+  color: var(--kolay-typedoc-type, light-dark(#6639ba, #d2a8ff));
+}
+
+.typedoc__unknown__yield,
+.typedoc__intrinsic,
+.typedoc__literal {
+  color: var(--kolay-typedoc-builtin, light-dark(#116329, #7ee787));
+}
 
 .typedoc__type-link,
 .typedoc__unknown__yield,
@@ -48,6 +69,12 @@
   display: inline-block;
   line-height: 1.5rem;
   font-weight: bold;
+  color: var(--kolay-typedoc-name, light-dark(#0550ae, #79c0ff));
+}
+
+/* the root declaration's name is a heading, not a code token */
+section > .typedoc__declaration > .typedoc__declaration-name {
+  color: inherit;
 }
 
 .typedoc__declaration {
@@ -90,6 +117,7 @@
   > .typedoc__declaration-name::after {
     content: ":";
     font-weight: normal;
+    color: var(--kolay-typedoc-punctuation, light-dark(#59636e, #9198a1));
   }
 
   > .typedoc__declaration-type {
@@ -266,6 +294,7 @@ section {
     &::after {
       content: ": ";
       font-weight: normal;
+      color: var(--kolay-typedoc-punctuation, light-dark(#59636e, #9198a1));
     }
   }
 
@@ -308,7 +337,10 @@ section {
   .typedoc__declaration
   .typedoc-rendered-comment {
   font-size: 0.85em;
-  color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+  color: var(
+    --kolay-typedoc-comment,
+    var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent))
+  );
   margin: 0.1rem 0 0.4rem 0.9rem;
 
   :is(p, pre) {
@@ -326,6 +358,11 @@ section {
 .typedoc__reference__typeArgument {
   display: inline;
   width: auto;
+}
+
+/* the < > , between type arguments; tokens inside re-color themselves */
+.typedoc__reference__typeArguments {
+  color: var(--kolay-typedoc-punctuation, light-dark(#59636e, #9198a1));
 }
 
 .typedoc__reference__typeArgument + .typedoc__reference__typeArgument::before {
@@ -366,6 +403,12 @@ section {
   content: ", ";
 }
 
+.typedoc__function__open,
+.typedoc__function__close,
+.typedoc__function__parameter__container + .typedoc__function__parameter__container::before {
+  color: var(--kolay-typedoc-punctuation, light-dark(#59636e, #9198a1));
+}
+
 .typedoc__function__close {
   margin: 0 0.25rem;
 }
@@ -376,10 +419,12 @@ section {
   font-family: var(--pico-font-family-monospace, monospace);
   font-size: 0.9em;
   font-weight: 600;
+  color: var(--kolay-typedoc-param, light-dark(#953800, #ffa657));
 
   &::after {
     content: ": ";
     font-weight: normal;
+    color: var(--kolay-typedoc-punctuation, light-dark(#59636e, #9198a1));
   }
 }
 
@@ -390,7 +435,10 @@ section {
 
   .typedoc-rendered-comment {
     font-size: 0.85em;
-    color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+    color: var(
+      --kolay-typedoc-comment,
+      var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent))
+    );
     margin: 0.1rem 0 0.4rem 0.9rem;
 
     :is(p, pre) {
@@ -428,6 +476,7 @@ section {
 
 .typedoc__union__type::before {
   content: "| ";
+  color: var(--kolay-typedoc-punctuation, light-dark(#59636e, #9198a1));
 }
 
 .typedoc__union .typedoc__union__type:first-child::before {
@@ -490,10 +539,12 @@ section {
     font-family: var(--pico-font-family-monospace, monospace);
     font-weight: 600;
     font-size: inherit;
+    color: var(--kolay-typedoc-name, light-dark(#0550ae, #79c0ff));
 
     &::after {
       content: ": ";
       font-weight: normal;
+      color: var(--kolay-typedoc-punctuation, light-dark(#59636e, #9198a1));
     }
   }
 }
@@ -623,7 +674,10 @@ section {
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+    color: var(
+      --kolay-typedoc-comment,
+      var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent))
+    );
     margin: 0.5rem 0 0.15rem;
   }
 
@@ -674,7 +728,10 @@ section {
     padding-top: 0;
     margin: 0.1rem 0 0.4rem 0.9rem;
     font-size: 0.85em;
-    color: var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent));
+    color: var(
+      --kolay-typedoc-comment,
+      var(--pico-muted-color, color-mix(in oklab, currentColor 65%, transparent))
+    );
   }
 }
 


### PR DESCRIPTION
Signatures now scan like highlighted code — each token kind gets its own color, controlled by CSS variables (set on `:root` or any ancestor; defaults are `light-dark()` aware):

| variable | colors |
| --- | --- |
| `--kolay-typedoc-name` | member & declaration names (blue) |
| `--kolay-typedoc-type` | type references (purple) |
| `--kolay-typedoc-builtin` | intrinsics & literals (green) |
| `--kolay-typedoc-param` | function parameter names (orange) |
| `--kolay-typedoc-punctuation` | `:` `( ) =>` `\|` `< >` (muted) |
| `--kolay-typedoc-comment` | doc comments inside shapes |

Chip borders/backgrounds already derive from `currentColor`, so they tint automatically with whatever colors are set. The root declaration's name stays a plain heading (colors are for the code tokens, not the section labels).

New **TypeDoc → Customizing → Rendering** page: the variable table, a live demo overriding the variables through an inline `style` attribute (scoping is just CSS), and the `typedoc__*` class hooks with the reading model for deeper restyling.

Verified light theme at 1400px and the demo's overrides live; docs-app 50/50 (page added to the render sweep), lint 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)