### PR TITLE
docs() sources expose meta: repository URL, docs path, meta.jsonc

### DIFF
--- a/docs-app/src/templates/development/configuring-docs.gjs.md
+++ b/docs-app/src/templates/development/configuring-docs.gjs.md
@@ -142,8 +142,20 @@ import { addRoutes as addFooRoutes, manifest } from "virtual:kolay/docs/foo";
 
 - `manifest` — the group's own manifest (`{ name, list, tree }`)
 - `pages` — the group's page loaders, like `import.meta.glob`
+- `meta` — where the source lives:
 
-The co-located pages have one too: `virtual:kolay/docs/Home`.
+  ```js
+  import { meta } from "virtual:kolay/docs/foo";
+
+  meta.url; // the repository URL, e.g. 'https://github.com/universal-ember/kolay'
+  meta.docsPath; // the repo-relative path to this source's docs, e.g. 'docs'
+  ```
+
+  `url` comes from the `repository` field of the package.json at the repository root; `docsPath` is where the `docs()` source sits inside that repository — together they can build "edit this page" links.
+
+  A `meta.jsonc` (or `meta.json`) at the root of the source mixes its content in — put anything you want alongside the derived fields (its keys win over them). This is the same file that can hold the source's top-level [`order`](/development/ordering-pages.md), so that key comes along when present.
+
+The co-located pages have one too: `virtual:kolay/docs/Home` (its source is the templates directory, so that is what `docsPath` and `meta.jsonc` refer to).
 
 Group info across _all_ groups comes from the metamanifest, `kolay/compiled-docs:virtual` — it lists every group and how to load its module. `setupKolay()` loads all of them in parallel behind the scenes (via `loadCompiledDocs` from `kolay`), so by default the whole site's navigation is available up front.
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -24,7 +24,7 @@ export { getIndexPage, isCollection, isIndex } from './utils.ts';
 
 // Types
 export type { Collection, Manifest, Page } from '../types.ts';
-export type { DocsGroupModule, MetaManifest } from './load-compiled-docs.ts';
+export type { DocsGroupModule, DocsSourceMeta, MetaManifest } from './load-compiled-docs.ts';
 export type { DocModule, DocSource } from './services/compiled-doc.ts';
 export type { SetupOptions } from './services/docs.ts';
 export type { DocsService } from './services/docs.ts';

--- a/src/browser/load-compiled-docs.ts
+++ b/src/browser/load-compiled-docs.ts
@@ -2,6 +2,24 @@ import type { Collection, Manifest, Page } from '../types.ts';
 import type { ComponentLike } from '@glint/template';
 
 /**
+ * A docs source's meta, from `virtual:kolay/docs/<groupName>`:
+ * derived from the repository root's package.json, mixed with the
+ * content of a `meta.jsonc` at the root of the source (user keys win).
+ */
+export interface DocsSourceMeta {
+  /**
+   * The repository URL (GitHub, etc), from the root package.json's
+   * `repository` field.
+   */
+  url?: string;
+  /**
+   * The repo-relative path to this source's docs.
+   */
+  docsPath?: string;
+  [key: string]: unknown;
+}
+
+/**
  * What each `virtual:kolay/docs/<groupName>` module provides.
  */
 export interface DocsGroupModule {
@@ -10,6 +28,11 @@ export interface DocsGroupModule {
    * The group's own manifest.
    */
   manifest: { name: string; list: Page[]; tree: Collection };
+  /**
+   * The source's meta: repository URL, repo-relative docs path, and
+   * anything from the source root's `meta.jsonc`.
+   */
+  meta: DocsSourceMeta;
   /**
    * Similar to import.meta.glob — the group's page loaders, keyed by URL.
    */

--- a/src/browser/virtual/references.d.ts
+++ b/src/browser/virtual/references.d.ts
@@ -48,11 +48,14 @@ declare module 'kolay/setup' {
  * `docs('foo')` enables `virtual:kolay/docs/foo`:
  *
  * ```js
- * import { addRoutes as addFooRoutes, manifest } from 'virtual:kolay/docs/foo';
+ * import { addRoutes as addFooRoutes, manifest, meta } from 'virtual:kolay/docs/foo';
  * ```
  *
  * `addRoutes(context)` is pre-scoped to the group: it brings the group's
  * docs into whatever route it's called from.
+ *
+ * `meta` describes the source: its repository URL, its repo-relative
+ * docs path, and anything from a `meta.jsonc` at the source's root.
  */
 declare module 'virtual:kolay/docs/*' {
   import type { DocsGroupModule } from 'kolay';
@@ -61,4 +64,5 @@ declare module 'virtual:kolay/docs/*' {
   export const manifest: DocsGroupModule['manifest'];
   export const pages: DocsGroupModule['pages'];
   export const addRoutes: DocsGroupModule['addRoutes'];
+  export const meta: DocsGroupModule['meta'];
 }

--- a/src/build/plugins/setup.js
+++ b/src/build/plugins/setup.js
@@ -11,6 +11,7 @@ import send from 'send';
 import { virtualFile } from './helpers.js';
 import { reshape } from './markdown-pages/hydrate.js';
 import { readJSONC } from './markdown-pages/parse.js';
+import { sourceMeta } from './source-meta.js';
 import { normalizePath } from './utils.js';
 
 /**
@@ -168,6 +169,21 @@ function homeSource(cwd) {
   };
 }
 
+/**
+ * Where the Home source's own files live — its meta.jsonc (and the
+ * repo-relative docsPath) belong to the templates directory, not the
+ * app root.
+ */
+function homeMetaCwd(cwd) {
+  for (const candidate of ['src/templates', 'app/templates']) {
+    const dir = join(cwd, candidate);
+
+    if (existsSync(dir)) return dir;
+  }
+
+  return cwd;
+}
+
 function groupSource(group) {
   return {
     displayName: group.name,
@@ -220,15 +236,18 @@ export function docsVirtualGuard(state) {
 
 /**
  * The source of a `virtual:kolay/docs/<groupName>` module:
- * the group's manifest, its page loaders, and an `addRoutes` scoped to it.
+ * the group's manifest, its page loaders, its meta, and an `addRoutes`
+ * scoped to it.
  */
-function groupModuleContent({ manifestGroup, loaders }, { scopedTo } = {}) {
+function groupModuleContent({ manifestGroup, loaders, meta }, { scopedTo } = {}) {
   return stripIndent`
     import { addRoutes as _addRoutes } from 'kolay';
 
     export const name = ${JSON.stringify(manifestGroup.name)};
 
     export const manifest = ${JSON.stringify(manifestGroup)};
+
+    export const meta = ${JSON.stringify(meta ?? {})};
 
     export const pages = {
       ${Object.entries(loaders)
@@ -501,9 +520,11 @@ export const setup = (state) => {
          */
         importPath: docsModuleId('Home'),
         content: async () => {
-          const enumerated = await enumerateSource(homeSource(cwd), baseUrl);
+          const source = homeSource(cwd);
+          const enumerated = await enumerateSource(source, baseUrl);
+          const meta = await sourceMeta(homeMetaCwd(cwd));
 
-          return groupModuleContent(enumerated);
+          return groupModuleContent({ ...enumerated, meta });
         },
       },
       /**
@@ -515,8 +536,9 @@ export const setup = (state) => {
         importPath: docsModuleId(group.name),
         content: async () => {
           const enumerated = await enumerateSource(groupSource(group), baseUrl);
+          const meta = await sourceMeta(normalizePath(group.src));
 
-          return groupModuleContent(enumerated, { scopedTo: group.name });
+          return groupModuleContent({ ...enumerated, meta }, { scopedTo: group.name });
         },
       })),
     ]),

--- a/src/build/plugins/source-meta.js
+++ b/src/build/plugins/source-meta.js
@@ -1,0 +1,117 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+
+import { readJSONC } from './markdown-pages/parse.js';
+
+/**
+ * The repository root containing `dir`: the nearest ancestor with a
+ * `.git` entry (a directory — or a file, for worktrees and submodules).
+ *
+ * @param {string} dir
+ * @returns {string | undefined}
+ */
+export function findRepoRoot(dir) {
+  let current = dir;
+
+  while (true) {
+    if (existsSync(join(current, '.git'))) {
+      return current;
+    }
+
+    const parent = dirname(current);
+
+    if (parent === current) {
+      return undefined;
+    }
+
+    current = parent;
+  }
+}
+
+const HOST_SHORTHANDS = {
+  github: 'https://github.com/',
+  gitlab: 'https://gitlab.com/',
+  bitbucket: 'https://bitbucket.org/',
+};
+
+/**
+ * package.json's `repository` (string or object form) → a browsable
+ * https URL.
+ *
+ * @param {string | { type?: string; url?: string } | undefined} repository
+ * @returns {string | undefined}
+ */
+export function repositoryUrl(repository) {
+  let url = typeof repository === 'string' ? repository : repository?.url;
+
+  if (!url) return undefined;
+
+  url = url.replace(/^git\+/, '').replace(/\.git$/, '');
+
+  for (const [shorthand, host] of Object.entries(HOST_SHORTHANDS)) {
+    if (url.startsWith(`${shorthand}:`)) {
+      return host + url.slice(shorthand.length + 1);
+    }
+  }
+
+  // git@github.com:user/repo — scp-style ssh
+  const scp = url.match(/^git@([^:]+):(.+)$/);
+
+  if (scp) {
+    return `https://${scp[1]}/${scp[2]}`;
+  }
+
+  url = url.replace(/^(git|ssh):\/\/(git@)?/, 'https://');
+
+  if (url.startsWith('https://') || url.startsWith('http://')) {
+    return url;
+  }
+
+  // npm's bare `user/repo` shorthand means github
+  if (/^[^/]+\/[^/]+$/.test(url)) {
+    return `https://github.com/${url}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * The meta for one docs() source:
+ * - `url`: the repository URL, from the `repository` field of the
+ *   package.json at the repository root
+ * - `docsPath`: the repo-relative path to the source's docs
+ * - anything else from a `meta.jsonc` (or `meta.json`) at the root of
+ *   the source, mixed in (user keys win)
+ *
+ * @param {string} sourceCwd
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function sourceMeta(sourceCwd) {
+  const derived = {};
+  const repoRoot = findRepoRoot(sourceCwd);
+
+  if (repoRoot) {
+    derived.docsPath = relative(repoRoot, sourceCwd).split(sep).join('/');
+
+    const packagePath = join(repoRoot, 'package.json');
+
+    if (existsSync(packagePath)) {
+      const rootPackage = await readJSONC(packagePath);
+      const url = repositoryUrl(rootPackage?.repository);
+
+      if (url) {
+        derived.url = url;
+      }
+    }
+  }
+
+  for (const candidate of ['meta.jsonc', 'meta.json']) {
+    const configPath = join(sourceCwd, candidate);
+
+    if (existsSync(configPath)) {
+      return { ...derived, ...(await readJSONC(configPath)) };
+    }
+  }
+
+  return derived;
+}

--- a/src/build/plugins/source-meta.test.ts
+++ b/src/build/plugins/source-meta.test.ts
@@ -1,0 +1,68 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { findRepoRoot, repositoryUrl, sourceMeta } from './source-meta.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe('repositoryUrl', () => {
+  it.each([
+    [
+      'git+https://github.com/universal-ember/kolay.git',
+      'https://github.com/universal-ember/kolay',
+    ],
+    ['https://github.com/universal-ember/kolay', 'https://github.com/universal-ember/kolay'],
+    ['git://github.com/user/repo.git', 'https://github.com/user/repo'],
+    ['git@github.com:user/repo.git', 'https://github.com/user/repo'],
+    ['ssh://git@github.com/user/repo.git', 'https://github.com/user/repo'],
+    ['github:user/repo', 'https://github.com/user/repo'],
+    ['gitlab:user/repo', 'https://gitlab.com/user/repo'],
+    ['bitbucket:user/repo', 'https://bitbucket.org/user/repo'],
+    ['user/repo', 'https://github.com/user/repo'],
+  ])('%s → %s', (input, output) => {
+    expect(repositoryUrl(input)).toBe(output);
+  });
+
+  it('handles the object form', () => {
+    expect(
+      repositoryUrl({ type: 'git', url: 'git+https://github.com/universal-ember/kolay.git' })
+    ).toBe('https://github.com/universal-ember/kolay');
+  });
+
+  it('is undefined when there is nothing usable', () => {
+    expect(repositoryUrl(undefined)).toBeUndefined();
+    expect(repositoryUrl({})).toBeUndefined();
+    expect(repositoryUrl('gist:abc123')).toBeUndefined();
+  });
+});
+
+const repoRoot = findRepoRoot(here) ?? '<not found>';
+
+describe('findRepoRoot', () => {
+  it('finds this repository (a worktree: .git is a file)', () => {
+    expect(here.startsWith(repoRoot)).toBe(true);
+  });
+});
+
+describe('sourceMeta', () => {
+  it('derives url and docsPath, and mixes in the source-root meta file', async () => {
+    // the runtime docs source of this very repository — its meta.json
+    // (ordering) is user content and comes along
+    const meta = await sourceMeta(join(repoRoot, 'docs'));
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "docsPath": "docs",
+        "order": [
+          "rendering",
+          "navigation",
+          "utilities",
+          "demo-support",
+        ],
+        "url": "https://github.com/universal-ember/kolay",
+      }
+    `);
+  });
+});

--- a/test-apps/multiple-docs-routes/demos/meta.jsonc
+++ b/test-apps/multiple-docs-routes/demos/meta.jsonc
@@ -1,0 +1,4 @@
+{
+  // proves jsonc parses: user content mixed into the meta export
+  "package": "demo-kit",
+}

--- a/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.ts
+++ b/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.ts
@@ -3,7 +3,12 @@ import { module, test } from "qunit";
 import { setupApplicationTest } from "ember-qunit";
 
 import { docsManager } from "kolay";
-import { manifest as demosManifest, name as demosName } from "virtual:kolay/docs/demos";
+import {
+  manifest as demosManifest,
+  meta as demosMeta,
+  name as demosName,
+} from "virtual:kolay/docs/demos";
+import { meta as guidesMeta } from "virtual:kolay/docs/guides";
 
 module("Multiple docs routes", function (hooks) {
   setupApplicationTest(hooks);
@@ -23,6 +28,15 @@ module("Multiple docs routes", function (hooks) {
       demosManifest.list.map((page) => page.appRelativePath),
       ["/demos/components/buttons"],
     );
+  });
+
+  test("each docs() usage exposes its source's meta", function (assert) {
+    assert.strictEqual(demosMeta.url, "https://github.com/universal-ember/kolay");
+    assert.strictEqual(demosMeta.docsPath, "test-apps/multiple-docs-routes/demos");
+    assert.strictEqual(demosMeta.package, "demo-kit", "meta.jsonc content is mixed in");
+
+    assert.strictEqual(guidesMeta.docsPath, "test-apps/multiple-docs-routes/guides");
+    assert.notOk("package" in guidesMeta, "no meta.jsonc, no mixed-in content");
   });
 
   test("a co-located page renders from the root mount", async function (assert) {


### PR DESCRIPTION
Each `virtual:kolay/docs/<group>` module gains a `meta` export:

```js
import { meta } from "virtual:kolay/docs/foo";

meta.url;      // 'https://github.com/universal-ember/kolay'
meta.docsPath; // 'test-apps/multiple-docs-routes/foo'
```

- **`url`** — from the `repository` field of the package.json at the repository root. The root is found by walking up from the source to the nearest `.git` entry (directory *or* file, so worktrees/submodules work). All the common `repository` forms normalize to a browsable https URL: `git+https://…​.git`, `git://`, scp-style `git@host:user/repo`, `ssh://`, `github:`/`gitlab:`/`bitbucket:` shorthands, bare `user/repo`, and the object form.
- **`docsPath`** — the repo-relative path to the source's docs. Together with `url` this can build "edit this page" links.
- **`meta.jsonc`** (or `meta.json`) at the source root mixes its content in, user keys winning — it's the same file that can hold the source's top-level `order`, so that key comes along when present. For the co-located Home source, the templates directory is the source root.

Documented on Development → Configuring docs() under the virtual-module exports; `DocsSourceMeta` is exported from `kolay` and the `kolay/virtual` wildcard declaration includes `meta`.

Tests: 13 new vitest cases (URL normalization table, worktree-aware repo-root discovery, an inline-snapshot of this repo's own `docs/` meta) and a test-app assertion covering the derived fields, the jsonc mixin (comment included to prove parsing), and a source *without* a meta file. Full suite: vitest 118/118, multiple-docs-routes 9/9, docs-app 50/50, lint 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)