### PR TITLE
docs-app: Prebuilt docs UI page (@universal-ember/docs-support)

### DIFF
--- a/docs-app/src/templates/application.gts
+++ b/docs-app/src/templates/application.gts
@@ -87,7 +87,11 @@ const SideNav: TOC<{ Element: HTMLElement }> = <template>
       <:collection as |x|>
         {{#if x.index}}
           <x.index.Link>
-            {{sentenceCase x.collection.name}}
+            {{#if x.index.page.title}}
+              {{x.index.page.title}}
+            {{else}}
+              {{sentenceCase x.collection.name}}
+            {{/if}}
           </x.index.Link>
         {{else}}
           {{sentenceCase x.collection.name}}

--- a/docs-app/src/templates/meta.jsonc
+++ b/docs-app/src/templates/meta.jsonc
@@ -1,4 +1,4 @@
 {
   // Install first, helpers last
-  "order": ["install", "authoring", "development", "migrations", "ecosystem"],
+  "order": ["install", "prebuilt-ui", "authoring", "development", "migrations", "ecosystem"],
 }

--- a/docs-app/src/templates/prebuilt-ui/index.gjs.md
+++ b/docs-app/src/templates/prebuilt-ui/index.gjs.md
@@ -1,0 +1,68 @@
+# Prebuilt docs UI
+
+[GitHub](https://github.com/universal-ember/ember-primitives/tree/main/packages/docs-support) · [npm](https://www.npmjs.com/package/@universal-ember/docs-support)
+
+kolay ships headless building blocks — this site assembles its own UI from them (that's what the [Development](/development/rendering-pages) section walks through). If you'd rather start from a finished docs UI, `@universal-ember/docs-support` is the prebuilt one: it is what [ember-primitives](https://ember-primitives.pages.dev), [universal-ember/form](https://github.com/universal-ember/form), and the other universal-ember projects use for their kolay-powered docs sites.
+
+Two components carry the whole site:
+
+- `<Shell>` wraps the app. It pulls in the full site CSS — prose typography, shiki code-fence themes, header and nav chrome — and keeps the light/dark body classes in sync with `ember-primitives/color-scheme`.
+- `<PageLayout>` is the whole docs page: a sticky header with `:logoLink` and `:topRight` blocks, a responsive side nav (a drawer on small screens) rendering your kolay manifest, and kolay's `<Page>` fully wired — a shimmer loader while a page loads and compiles, your `:error` block when something fails, the rendered prose (with scroll reset) on success, and an optional `:editLink` block.
+
+Alongside them: `<IndexPage>` for a landing page, `<Callout>` for asides in your markdown, `<ThemeToggle>`, `<Article>`, link components, and the standalone error/loader pieces (`<OopsError>`, `<PageError>`, `<PageLoader>`).
+
+## Wiring it up
+
+The application template wraps everything in the shell:
+
+```gjs
+// app/templates/application.gts
+import { Shell } from "@universal-ember/docs-support";
+
+<template>
+  <Shell>
+    {{outlet}}
+  </Shell>
+</template>
+```
+
+and the docs route template is one `<PageLayout>`:
+
+```gts
+// app/templates/page.gts
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
+import { OopsError, PageLayout } from "@universal-ember/docs-support";
+import { meta } from "virtual:kolay/docs/Home";
+
+import { Logo } from "./icons";
+
+function editUrl(currentURL) {
+  return `${meta.url}/edit/main/${meta.docsPath}${currentURL.replace(/\.md$/, "")}.gjs.md`;
+}
+
+export default class DocsPage extends Component {
+  @service router;
+
+  <template>
+    <PageLayout>
+      <:logoLink>
+        <Logo />
+      </:logoLink>
+      <:error as |error|>
+        <OopsError @error={{error}} />
+      </:error>
+      <:editLink as |Link|>
+        <Link @href={{editUrl this.router.currentURL}}>
+          Edit this page
+        </Link>
+      </:editLink>
+    </PageLayout>
+  </template>
+}
+```
+
+(The edit link builds from the group's [`meta`](/development/configuring-docs) — the repository URL and the repo-relative docs path come from your repository's own package.json.)
+
+Everything else is regular kolay: `docs()` in the vite config, `setupKolay` in the application route, `addRoutes` in the router — [Install](/install/index) covers that part.

--- a/docs-app/src/templates/prebuilt-ui/index.json
+++ b/docs-app/src/templates/prebuilt-ui/index.json
@@ -1,0 +1,1 @@
+{ "title": "Prebuilt docs UI" }

--- a/docs-app/tests/docs-app/home-nav-test.gts
+++ b/docs-app/tests/docs-app/home-nav-test.gts
@@ -11,7 +11,14 @@ module('Home docs navigation', function (hooks) {
     const nav = document.querySelector('aside nav');
     const text = nav?.textContent?.replaceAll(/\s+/g, ' ') ?? '';
 
-    const sections = ['Install', 'Authoring', 'Development', 'Migrations', 'Ecosystem'];
+    const sections = [
+      'Install',
+      'Prebuilt docs UI',
+      'Authoring',
+      'Development',
+      'Migrations',
+      'Ecosystem',
+    ];
     const positions = sections.map((section) => text.indexOf(section));
 
     assert.deepEqual(
@@ -60,6 +67,7 @@ module('Home docs navigation', function (hooks) {
       ['/ecosystem/ember-repl', 'ember-repl'],
       ['/ecosystem/ember-mobile-menu', 'ember-mobile-menu'],
       ['/TypeDoc/customizing/rendering', 'Customizing rendering'],
+      ['/prebuilt-ui/index', 'Prebuilt docs UI'],
     ]) {
       await visit(url as string);
 


### PR DESCRIPTION
New top-level Home page between Install and Authoring: **Prebuilt docs UI**, covering `@universal-ember/docs-support` — the finished docs UI that ember-primitives, universal-ember/form, and the other universal-ember projects use on top of kolay (kolay's own site keeps hand-rolling its UI, which the page points out and routes to the Development section for).

Content (sourced from the real package and ember-primitives' docs-app):

- The two carrying components: `<Shell>` (site CSS + light/dark body-class sync) and `<PageLayout>` (sticky header with `:logoLink`/`:topRight`, responsive side nav over the kolay manifest, kolay's `<Page>` wired with loader/error/prose and an optional `:editLink`).
- The standalone pieces (`<IndexPage>`, `<Callout>`, `<ThemeToggle>`, error/loader components).
- A wiring recipe — the `page.gts` example builds its "Edit this page" URL from the group's `meta` (`url` + `docsPath`), dogfooding #344.

Mechanical bit: single-page sections are labeled `sentenceCase(folderName)`, which can't spell "UI" — the nav's collection block now prefers an index page's json `title` when present.

Tests: section-order list gains the entry, page added to the render sweep. docs-app 50/50, lint 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)