### PR TITLE
docs: state the runtime-vs-build-time import trade-off sharply

### DIFF
--- a/docs-app/src/templates/authoring/code-fences.gjs.md
+++ b/docs-app/src/templates/authoring/code-fences.gjs.md
@@ -68,7 +68,7 @@ An `hbs` fence is implicitly wrapped in a template, so it's the quickest way to 
 Live fences can `import` from anything your app can import from. To use components or helpers _without_ importing them in every fence:
 
 - for `.gjs.md` files: the [`scope` option of `docs()`](/development/configuring-docs.md) — a string of import statements prepended to every file at build time
-- for `.md` files: the `topLevelScope` and `modules` options of `setupKolay()` — values and importable modules provided to the runtime compiler
+- for `.md` files: the `topLevelScope` and `modules` options of `setupKolay()` — values and importable modules provided to the runtime compiler. The `modules` map is the complete import universe for runtime demos: every library they import, at any depth, resolves from it — never from the build's module graph
 
 By default, the runtime scope already provides `<Shadowed>` (from `ember-primitives`) for style isolation, and the [TypeDoc components](/TypeDoc/plugin/api-docs.md): `<APIDocs>`, `<ComponentSignature>`, `<ModifierSignature>`, `<HelperSignature>`, and `<CommentQuery>`.
 

--- a/docs-app/src/templates/authoring/code-fences.gjs.md
+++ b/docs-app/src/templates/authoring/code-fences.gjs.md
@@ -68,7 +68,7 @@ An `hbs` fence is implicitly wrapped in a template, so it's the quickest way to 
 Live fences can `import` from anything your app can import from. To use components or helpers _without_ importing them in every fence:
 
 - for `.gjs.md` files: the [`scope` option of `docs()`](/development/configuring-docs.md) — a string of import statements prepended to every file at build time
-- for `.md` files: the `topLevelScope` and `modules` options of `setupKolay()` — values and importable modules provided to the runtime compiler. The `modules` map is the complete import universe for runtime demos: every library they import, at any depth, resolves from it — never from the build's module graph
+- for `.md` files: the `topLevelScope` and `modules` options of `setupKolay()` — values and importable modules provided to the runtime compiler. The `modules` map is the complete import universe for runtime demos: every library they import, at any depth, resolves from it — never from the build's module graph. The Setup section of [Install](/install/index.md) shows it configured
 
 By default, the runtime scope already provides `<Shadowed>` (from `ember-primitives`) for style isolation, and the [TypeDoc components](/TypeDoc/plugin/api-docs.md): `<APIDocs>`, `<ComponentSignature>`, `<ModifierSignature>`, `<HelperSignature>`, and `<CommentQuery>`.
 

--- a/docs-app/src/templates/authoring/index.gjs.md
+++ b/docs-app/src/templates/authoring/index.gjs.md
@@ -17,7 +17,7 @@ Plain `.md` files are shipped as raw text with your app's static assets. When a 
 **Cons:**
 
 - Slightly slower page transitions (compilation happens on each visit, though results are cached in an LRU)
-- Live demos in `.md` codefences use the runtime compiler, so anything you want available in those demos must be provided through the `modules` and `topLevelScope` options passed to `setupKolay()`
+- Demo imports are not resolved by the build. The runtime compiler resolves imports only from what `setupKolay()` provides: every library your `.md` demos import — at any depth, including anything those libraries lead the demos to import — must be declared in `modules` (values can also be handed to the scope directly via `topLevelScope`). An import the map doesn't declare fails to resolve, even though the library sits installed in `node_modules`.
 
 ### Example
 
@@ -39,11 +39,12 @@ Files ending in `.gjs.md` are compiled during the build (by the `docs()` plugin)
 
 - Instant page transitions — the compiled component is code-split and loaded like any other module
 - Live demos are real GJS components, so you get full build-time error checking
+- Demo imports resolve through the build, like any source file — anything installed works, at any depth, with no registration
 - You can use the `scope` build option to make components/helpers available inside live codefences without any runtime setup
 
 **Cons:**
 
-- Each `.gjs.md` file adds to your build, so many of them can increase build times
+- Every `.gjs.md` file adds compile work to the build — build time grows with your page count, where `.md` stays flat no matter how many pages exist
 - Requires a build step; raw markdown content is not available at runtime
 
 ### Example

--- a/docs-app/src/templates/authoring/index.gjs.md
+++ b/docs-app/src/templates/authoring/index.gjs.md
@@ -17,7 +17,7 @@ Plain `.md` files are shipped as raw text with your app's static assets. When a 
 **Cons:**
 
 - Slightly slower page transitions (compilation happens on each visit, though results are cached in an LRU)
-- Demo imports are not resolved by the build. The runtime compiler resolves imports only from what `setupKolay()` provides: every library your `.md` demos import — at any depth, including anything those libraries lead the demos to import — must be declared in `modules` (values can also be handed to the scope directly via `topLevelScope`). An import the map doesn't declare fails to resolve, even though the library sits installed in `node_modules`.
+- Demo imports are not resolved by the build. The runtime compiler resolves imports only from what `setupKolay()` provides: every library your `.md` demos import — at any depth, including anything those libraries lead the demos to import — must be declared in `modules` (values can also be handed to the scope directly via `topLevelScope`). An import the map doesn't declare fails to resolve, even though the library sits installed in `node_modules`. The Setup section of [Install](/install/index.md) shows the map being configured.
 
 ### Example
 

--- a/docs-app/src/templates/install/index.gjs.md
+++ b/docs-app/src/templates/install/index.gjs.md
@@ -187,7 +187,7 @@ export default class ApplicationRoute extends Route {
     });
 
     const manifest = await setupKolay(this, {
-      resolve: {
+      modules: {
         "ember-primitives": () => import("ember-primitives"),
         kolay: () => import("kolay"),
       },


### PR DESCRIPTION
The Authoring index's pros/cons already gestured at both halves of the trade-off, but neither was stated sharply:

- **`.md` (runtime compiled)**: the con bullet said demo imports "must be provided through `modules`/`topLevelScope`" without conveying that the map is the *complete* import universe — every library a demo imports, **at any depth**, resolves from it and never from the build's module graph; an undeclared import fails even though the package sits in `node_modules`.
- **`.gjs.md` (build-time compiled)**: the mirror image wasn't stated at all — imports resolve through the build like any source file (anything installed works, no registration), and the cost side now says plainly that build time grows with page count where `.md` stays flat no matter how many pages exist.

Also expanded the corresponding line under Code fences → providing things to demos.

docs-app 50/50, lint 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)