### PR TITLE
demos(): alias a directory of components for live codefences

### DIFF
--- a/docs-app/demos/counter.gjs
+++ b/docs-app/demos/counter.gjs
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+export default class Counter extends Component {
+  @tracked count = 0;
+
+  increment = () => this.count++;
+
+  <template>
+    <button type="button" data-demo="counter" {{on "click" this.increment}}>
+      Clicked
+      {{this.count}}
+      times
+    </button>
+  </template>
+}

--- a/docs-app/src/registry.ts
+++ b/docs-app/src/registry.ts
@@ -23,7 +23,7 @@ function formatAsResolverEntries(imports: Record<string, unknown>) {
  */
 const resolverRegistry = {
   ...formatAsResolverEntries(
-    import.meta.glob('./templates/**/*.{gjs,gts,js,ts,md}', { eager: true })
+    import.meta.glob('./templates/**/*.{gjs,gts,js,ts,gjs.md,gts.md}', { eager: true })
   ),
   ...formatAsResolverEntries(import.meta.glob('./services/**/*.{js,ts}', { eager: true })),
   ...formatAsResolverEntries(import.meta.glob('./routes/**/*.{js,ts}', { eager: true })),

--- a/docs-app/src/templates/authoring/code-fences.gjs.md
+++ b/docs-app/src/templates/authoring/code-fences.gjs.md
@@ -69,6 +69,7 @@ Live fences can `import` from anything your app can import from. To use componen
 
 - for `.gjs.md` files: the [`scope` option of `docs()`](/development/configuring-docs.md) — a string of import statements prepended to every file at build time
 - for `.md` files: the `topLevelScope` and `modules` options of `setupKolay()` — values and importable modules provided to the runtime compiler. The `modules` map is the complete import universe for runtime demos: every library they import, at any depth, resolves from it — never from the build's module graph. The Setup section of [Install](/install/index.md) shows it configured
+- for whole demo components in either file type: the [`demos()` plugin](/authoring/sharing-demos.md) — a directory of components aliased for fences to import, wired into the runtime compiler automatically
 
 By default, the runtime scope already provides `<Shadowed>` (from `ember-primitives`) for style isolation, and the [TypeDoc components](/TypeDoc/plugin/api-docs.md): `<APIDocs>`, `<ComponentSignature>`, `<ModifierSignature>`, `<HelperSignature>`, and `<CommentQuery>`.
 

--- a/docs-app/src/templates/authoring/meta.json
+++ b/docs-app/src/templates/authoring/meta.json
@@ -1,3 +1,9 @@
 {
-  "order": ["markdown-features", "code-fences", "links-and-images", "extending-markdown"]
+  "order": [
+    "markdown-features",
+    "code-fences",
+    "sharing-demos",
+    "links-and-images",
+    "extending-markdown"
+  ]
 }

--- a/docs-app/src/templates/authoring/sharing-demos.md
+++ b/docs-app/src/templates/authoring/sharing-demos.md
@@ -1,0 +1,38 @@
+# Sharing demos
+
+Live codefences are great for small examples, but real demos outgrow them: you want the same demo on several pages, editor tooling while writing it, and room for more than one component. The `demos()` plugin gives a directory of components an import alias every live fence understands:
+
+```js
+// vite.config.js
+import { demos, docs } from "kolay/vite";
+
+export default {
+  plugins: [docs(), demos(import.meta.resolve("./demos"), { as: "demos/site" })],
+};
+```
+
+Every file in the directory becomes importable under the alias, with the `virtual:` prefix always added — `demos/counter.gjs` is `virtual:demos/site/counter`:
+
+````md
+```gjs live
+import Counter from "virtual:demos/site/counter";
+
+<template><Counter /></template>
+```
+````
+
+That exact fence, live:
+
+```gjs live preview
+import Counter from "virtual:demos/site/counter";
+
+<template><Counter /></template>
+```
+
+This page is a `.md` file, so the fence above compiles in the browser — the import resolves through the runtime compiler with no [`modules` configuration](/install/index.md): `setupKolay` learns every `demos()` alias automatically. In `.gjs.md` files the same import compiles through the build, like any other module.
+
+## Conventions
+
+- File extensions are dropped: `counter.gjs`, `counter.gts`, `counter.js`, and `counter.ts` are all imported as `…/counter`
+- An `index` file provides its directory: `demos/index.gjs` is `virtual:demos/site`, and `demos/forms/index.gjs` is `virtual:demos/site/forms`
+- Use the plugin once per directory, each usage with its own `as`

--- a/docs-app/src/templates/authoring/sharing-demos.md
+++ b/docs-app/src/templates/authoring/sharing-demos.md
@@ -7,15 +7,15 @@ Live codefences are great for small examples, but real demos outgrow them: you w
 import { demos, docs } from "kolay/vite";
 
 export default {
-  plugins: [docs(), demos(import.meta.resolve("./demos"), { as: "demos/site" })],
+  plugins: [docs(), demos(import.meta.resolve("./demos"), { as: "#demos/site" })],
 };
 ```
 
-Every file in the directory becomes importable under the alias, with the `virtual:` prefix always added — `demos/counter.gjs` is `virtual:demos/site/counter`:
+Every file in the directory becomes importable under the `as` specifier, used verbatim — `demos/counter.gjs` is `#demos/site/counter`:
 
 ````md
 ```gjs live
-import Counter from "virtual:demos/site/counter";
+import Counter from "#demos/site/counter";
 
 <template><Counter /></template>
 ```
@@ -24,7 +24,7 @@ import Counter from "virtual:demos/site/counter";
 That exact fence, live:
 
 ```gjs live preview
-import Counter from "virtual:demos/site/counter";
+import Counter from "#demos/site/counter";
 
 <template><Counter /></template>
 ```
@@ -34,5 +34,6 @@ This page is a `.md` file, so the fence above compiles in the browser — the im
 ## Conventions
 
 - File extensions are dropped: `counter.gjs`, `counter.gts`, `counter.js`, and `counter.ts` are all imported as `…/counter`
-- An `index` file provides its directory: `demos/index.gjs` is `virtual:demos/site`, and `demos/forms/index.gjs` is `virtual:demos/site/forms`
+- `as` may be any valid import URI; the `#` prefix (Node's [subpath-import](https://nodejs.org/api/packages.html#subpath-imports) convention) makes it unmistakably not-an-npm-package
+- An `index` file provides its directory: `demos/index.gjs` is `#demos/site`, and `demos/forms/index.gjs` is `#demos/site/forms`
 - Use the plugin once per directory, each usage with its own `as`

--- a/docs-app/tests/docs-app/home-nav-test.gts
+++ b/docs-app/tests/docs-app/home-nav-test.gts
@@ -60,6 +60,7 @@ module('Home docs navigation', function (hooks) {
       ['/authoring/markdown-features', 'Markdown features'],
       ['/authoring/code-fences', 'Code fences'],
       ['/authoring/extending-markdown', 'Extending markdown'],
+      ['/authoring/sharing-demos', 'Sharing demos'],
       ['/Runtime/rendering/compiled', 'Compiled'],
       ['/migrations/upgrading-from-5x', 'Upgrading from 5.x'],
       ['/ecosystem/memory-scroll', 'memory-scroll'],
@@ -74,6 +75,13 @@ module('Home docs navigation', function (hooks) {
       assert.dom('[data-page-error]').doesNotExist(`${url} has no error`);
       assert.dom('h1').containsText(heading as string, `${url} renders`);
     }
+  });
+
+  test('a runtime fence imports a demos() alias, with no modules config', async function (assert) {
+    await visit('/authoring/sharing-demos');
+
+    assert.dom('[data-page-error]').doesNotExist();
+    assert.dom('[data-demo=counter]').containsText('Clicked 0 times');
   });
 
   test('the links-and-images page renders its image samples', async function (assert) {

--- a/docs-app/vite.config.js
+++ b/docs-app/vite.config.js
@@ -2,7 +2,7 @@ import { ember, extensions } from '@embroider/vite';
 
 import { babel } from '@rollup/plugin-babel';
 import rehypeShiki from '@shikijs/rehype';
-import { apiDocs, docs } from 'kolay/vite';
+import { apiDocs, demos, docs } from 'kolay/vite';
 import info from 'unplugin-info/vite';
 import { defineConfig } from 'vite';
 import inspect from 'vite-plugin-inspect';
@@ -44,6 +44,8 @@ export default defineConfig(async ({ mode }) => {
         ...sharedMarkdownOptions,
       }),
       apiDocs(['kolay', 'ember-primitives', 'ember-resources', 'ember-repl']),
+      // live codefences import these as 'virtual:demos/site/*'
+      demos(import.meta.resolve('./demos', import.meta.url), { as: 'demos/site' }),
       babel({
         babelHelpers: 'runtime',
         extensions,

--- a/docs-app/vite.config.js
+++ b/docs-app/vite.config.js
@@ -44,8 +44,8 @@ export default defineConfig(async ({ mode }) => {
         ...sharedMarkdownOptions,
       }),
       apiDocs(['kolay', 'ember-primitives', 'ember-resources', 'ember-repl']),
-      // live codefences import these as 'virtual:demos/site/*'
-      demos(import.meta.resolve('./demos', import.meta.url), { as: 'demos/site' }),
+      // live codefences import these as '#demos/site/*'
+      demos(import.meta.resolve('./demos', import.meta.url), { as: '#demos/site' }),
       babel({
         babelHelpers: 'runtime',
         extensions,

--- a/src/build/plugins/combined.js
+++ b/src/build/plugins/combined.js
@@ -2,6 +2,7 @@ import { createUnplugin } from 'unplugin';
 
 import { apiDocs } from './api-docs/index.js';
 import { validatePackages } from './api-docs/validate.js';
+import { demos as demosPlugin, parseDemosArgs } from './demos.js';
 import { parseDocsArgs } from './docs-args.js';
 import { gjsmd } from './gjs-md.js';
 import { docsVirtualGuard, setup } from './setup.js';
@@ -75,6 +76,19 @@ export function apiDocsPlugins(input) {
 }
 
 /**
+ * The demos plugin: aliases a directory of demo components so code
+ * fences can import them — `demos(path, { as: 'demos/foo' })` enables
+ * `import ... from 'virtual:demos/foo/<demo>'`. The runtime compiler
+ * learns the aliases automatically through `setupKolay`.
+ *
+ * @param {string} src - where the demos live (a path, or an `import.meta.resolve()`d URL)
+ * @param {{ as: string }} options
+ */
+export function demosPlugins(src, options) {
+  return [demosPlugin(createState(parseDemosArgs(src, options)))].filter(Boolean);
+}
+
+/**
  * unplugin factories only receive one argument, so the public two-argument
  * form (see 'kolay/vite') passes `[groupName, options]` as a tuple.
  */
@@ -85,3 +99,11 @@ export const docs = /* #__PURE__ */ createUnplugin((args) =>
 const apiDocsUnplugin = /* #__PURE__ */ createUnplugin(apiDocsPlugins);
 
 export { apiDocsUnplugin as apiDocs };
+
+/**
+ * unplugin factories only receive one argument, so the public
+ * two-argument form (see 'kolay/vite') passes `[src, options]` as a tuple.
+ */
+export const demos = /* #__PURE__ */ createUnplugin((args) =>
+  Array.isArray(args) ? demosPlugins(...args) : demosPlugins(args)
+);

--- a/src/build/plugins/combined.js
+++ b/src/build/plugins/combined.js
@@ -77,8 +77,8 @@ export function apiDocsPlugins(input) {
 
 /**
  * The demos plugin: aliases a directory of demo components so code
- * fences can import them — `demos(path, { as: 'demos/foo' })` enables
- * `import ... from 'virtual:demos/foo/<demo>'`. The runtime compiler
+ * fences can import them — `demos(path, { as: '#demos/foo' })` enables
+ * `import ... from '#demos/foo/<demo>'`. The runtime compiler
  * learns the aliases automatically through `setupKolay`.
  *
  * @param {string} src - where the demos live (a path, or an `import.meta.resolve()`d URL)

--- a/src/build/plugins/demos.js
+++ b/src/build/plugins/demos.js
@@ -6,8 +6,6 @@ import { stripIndent } from 'common-tags';
 
 import { normalizePath } from './utils.js';
 
-const VIRTUAL_PREFIX = 'virtual:';
-
 /**
  * Extensions a demo may have — the alias always omits them.
  */
@@ -18,7 +16,11 @@ const EXTENSION_PATTERN = new RegExp(`\\.(${DEMO_EXTENSIONS.join('|')})$`);
 /**
  * demos() takes (pathToDemos, { as }):
  *
- * - `demos(import.meta.resolve('./demos'), { as: 'demos/foo' })`
+ * - `demos(import.meta.resolve('./demos'), { as: '#demos/foo' })`
+ *
+ * The `as` is the import specifier, used verbatim — any valid import
+ * URI works; the `#` prefix (Node's subpath-import convention) makes
+ * it unmistakably not-an-npm-package.
  *
  * @param {string} src - where the demos live (a path, or an `import.meta.resolve()`d URL)
  * @param {{ as: string }} options
@@ -28,7 +30,7 @@ export function parseDemosArgs(src, options) {
   if (typeof src !== 'string' || src.length === 0) {
     throw new Error(
       `demos() requires a path to the demos as its first argument, e.g. ` +
-        `demos(import.meta.resolve('./demos'), { as: 'demos/foo' })`
+        `demos(import.meta.resolve('./demos'), { as: '#demos/foo' })`
     );
   }
 
@@ -36,21 +38,21 @@ export function parseDemosArgs(src, options) {
 
   if (typeof alias !== 'string' || alias.length === 0) {
     throw new Error(
-      `demos() requires an \`as\` option — the alias the demos are imported under, e.g. ` +
-        `demos(import.meta.resolve('./demos'), { as: 'demos/foo' }) enables ` +
-        `\`import ... from '${VIRTUAL_PREFIX}demos/foo/<demo>'\``
+      `demos() requires an \`as\` option — the specifier the demos are imported under, e.g. ` +
+        `demos(import.meta.resolve('./demos'), { as: '#demos/foo' }) enables ` +
+        `\`import ... from '#demos/foo/<demo>'\``
     );
   }
 
-  if (alias.startsWith(VIRTUAL_PREFIX)) {
+  const isValidImportUri =
+    !/\s/.test(alias) && !alias.startsWith('.') && !alias.startsWith('/') && !alias.endsWith('/');
+
+  if (!isValidImportUri) {
     throw new Error(
-      `demos()'s \`as\` should not include the '${VIRTUAL_PREFIX}' prefix — it is always added. ` +
-        `Use { as: '${alias.slice(VIRTUAL_PREFIX.length)}' }`
+      `demos()'s \`as\` is used verbatim as an import specifier, so it must be a valid ` +
+        `import URI: no whitespace, not relative, not starting or ending with '/'. ` +
+        `Received: '${alias}'. Try something like '#demos/foo'.`
     );
-  }
-
-  if (alias.startsWith('/') || alias.endsWith('/')) {
-    throw new Error(`demos()'s \`as\` should not start or end with '/'. Received: '${alias}'`);
   }
 
   const normalized = normalizePath(src);
@@ -66,9 +68,9 @@ export function parseDemosArgs(src, options) {
  * Every specifier a demos() source provides, mapped to the file it
  * resolves to:
  *
- * - each file, without its extension: `virtual:<as>/<file>`
+ * - each file, without its extension: `<as>/<file>`
  * - an index file also provides its directory:
- *   `virtual:<as>` (root), `virtual:<as>/<dir>` (nested)
+ *   `<as>` (root), `<as>/<dir>` (nested)
  *
  * @param {string} alias
  * @param {string} src - absolute path to the demos
@@ -82,12 +84,12 @@ export function demoSpecifiers(alias, src, entries) {
     const file = join(src, entry);
     const base = entry.replace(EXTENSION_PATTERN, '');
 
-    specifiers[`${VIRTUAL_PREFIX}${alias}/${base}`] = file;
+    specifiers[`${alias}/${base}`] = file;
 
     if (base === 'index') {
-      specifiers[`${VIRTUAL_PREFIX}${alias}`] = file;
+      specifiers[alias] = file;
     } else if (base.endsWith('/index')) {
-      specifiers[`${VIRTUAL_PREFIX}${alias}/${base.slice(0, -'/index'.length)}`] = file;
+      specifiers[`${alias}/${base.slice(0, -'/index'.length)}`] = file;
     }
   }
 
@@ -124,12 +126,12 @@ const RESOLVED_RUNTIME_MAP_ID = '\0kolay/demos:virtual';
  *
  * ```js
  * // vite.config.js
- * demos(import.meta.resolve('./demos'), { as: 'demos/foo' });
+ * demos(import.meta.resolve('./demos'), { as: '#demos/foo' });
  * ```
  *
  * ```js
  * // any live codefence, .md or .gjs.md
- * import Example from 'virtual:demos/foo/example';
+ * import Example from '#demos/foo/example';
  * ```
  *
  * The runtime compiler learns these automatically ('kolay/demos:virtual'
@@ -152,7 +154,7 @@ export const demos = (state) => {
         return { id: RESOLVED_RUNTIME_MAP_ID };
       }
 
-      const prefix = `${VIRTUAL_PREFIX}${state.options.alias}`;
+      const prefix = state.options.alias;
 
       if (id !== prefix && !id.startsWith(`${prefix}/`)) return;
 

--- a/src/build/plugins/demos.js
+++ b/src/build/plugins/demos.js
@@ -1,0 +1,239 @@
+import { existsSync } from 'node:fs';
+import { glob } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { stripIndent } from 'common-tags';
+
+import { normalizePath } from './utils.js';
+
+const VIRTUAL_PREFIX = 'virtual:';
+
+/**
+ * Extensions a demo may have — the alias always omits them.
+ */
+const DEMO_EXTENSIONS = ['gjs', 'gts', 'js', 'ts'];
+
+const EXTENSION_PATTERN = new RegExp(`\\.(${DEMO_EXTENSIONS.join('|')})$`);
+
+/**
+ * demos() takes (pathToDemos, { as }):
+ *
+ * - `demos(import.meta.resolve('./demos'), { as: 'demos/foo' })`
+ *
+ * @param {string} src - where the demos live (a path, or an `import.meta.resolve()`d URL)
+ * @param {{ as: string }} options
+ * @returns {{ src: string, alias: string }}
+ */
+export function parseDemosArgs(src, options) {
+  if (typeof src !== 'string' || src.length === 0) {
+    throw new Error(
+      `demos() requires a path to the demos as its first argument, e.g. ` +
+        `demos(import.meta.resolve('./demos'), { as: 'demos/foo' })`
+    );
+  }
+
+  const alias = options?.as;
+
+  if (typeof alias !== 'string' || alias.length === 0) {
+    throw new Error(
+      `demos() requires an \`as\` option — the alias the demos are imported under, e.g. ` +
+        `demos(import.meta.resolve('./demos'), { as: 'demos/foo' }) enables ` +
+        `\`import ... from '${VIRTUAL_PREFIX}demos/foo/<demo>'\``
+    );
+  }
+
+  if (alias.startsWith(VIRTUAL_PREFIX)) {
+    throw new Error(
+      `demos()'s \`as\` should not include the '${VIRTUAL_PREFIX}' prefix — it is always added. ` +
+        `Use { as: '${alias.slice(VIRTUAL_PREFIX.length)}' }`
+    );
+  }
+
+  if (alias.startsWith('/') || alias.endsWith('/')) {
+    throw new Error(`demos()'s \`as\` should not start or end with '/'. Received: '${alias}'`);
+  }
+
+  const normalized = normalizePath(src);
+
+  if (!existsSync(normalized)) {
+    throw new Error(`demos()'s path does not exist: '${normalized}' (from '${src}')`);
+  }
+
+  return { src: normalized, alias };
+}
+
+/**
+ * Every specifier a demos() source provides, mapped to the file it
+ * resolves to:
+ *
+ * - each file, without its extension: `virtual:<as>/<file>`
+ * - an index file also provides its directory:
+ *   `virtual:<as>` (root), `virtual:<as>/<dir>` (nested)
+ *
+ * @param {string} alias
+ * @param {string} src - absolute path to the demos
+ * @param {string[]} entries - files, relative to src
+ * @returns {Record<string, string>} specifier → absolute file path
+ */
+export function demoSpecifiers(alias, src, entries) {
+  const specifiers = {};
+
+  for (const entry of entries.toSorted()) {
+    const file = join(src, entry);
+    const base = entry.replace(EXTENSION_PATTERN, '');
+
+    specifiers[`${VIRTUAL_PREFIX}${alias}/${base}`] = file;
+
+    if (base === 'index') {
+      specifiers[`${VIRTUAL_PREFIX}${alias}`] = file;
+    } else if (base.endsWith('/index')) {
+      specifiers[`${VIRTUAL_PREFIX}${alias}/${base.slice(0, -'/index'.length)}`] = file;
+    }
+  }
+
+  return specifiers;
+}
+
+async function enumerate(src) {
+  const entries = [];
+
+  for await (const entry of glob(`**/*.{${DEMO_EXTENSIONS.join(',')}}`, {
+    cwd: src,
+    exclude: ['node_modules'],
+  })) {
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+/**
+ * All aliases contributed by every demos() usage in the config,
+ * in plugin order.
+ */
+function allUsages(state) {
+  return state.usages;
+}
+
+const RUNTIME_MAP_ID = 'kolay/demos:virtual';
+const RESOLVED_RUNTIME_MAP_ID = '\0kolay/demos:virtual';
+
+/**
+ * The demos plugin: aliases a directory of demo components so code
+ * fences can import them —
+ *
+ * ```js
+ * // vite.config.js
+ * demos(import.meta.resolve('./demos'), { as: 'demos/foo' });
+ * ```
+ *
+ * ```js
+ * // any live codefence, .md or .gjs.md
+ * import Example from 'virtual:demos/foo/example';
+ * ```
+ *
+ * The runtime compiler learns these automatically ('kolay/demos:virtual'
+ * feeds `setupKolay`), so `.md` fences need no `modules` configuration.
+ *
+ * @type {(state: { options: { src: string, alias: string }, usages: object[], isPrimary: boolean }) => import('unplugin').UnpluginOptions}
+ */
+export const demos = (state) => {
+  const name = 'kolay:demos';
+
+  /** @type {Record<string, string>} */
+  let specifiers = {};
+
+  return {
+    name,
+
+    resolveId(id) {
+      // the shared runtime map, served by the primary usage
+      if (id === RUNTIME_MAP_ID && state.isPrimary) {
+        return { id: RESOLVED_RUNTIME_MAP_ID };
+      }
+
+      const prefix = `${VIRTUAL_PREFIX}${state.options.alias}`;
+
+      if (id !== prefix && !id.startsWith(`${prefix}/`)) return;
+
+      const file = specifiers[id];
+
+      if (file) return file;
+
+      throw new Error(
+        `'${id}' does not exist in the demos() source '${state.options.src}'. ` +
+          `Available: ${Object.keys(specifiers).join(', ') || '(no demos found)'}`
+      );
+    },
+
+    loadInclude(id) {
+      return id === RESOLVED_RUNTIME_MAP_ID && state.isPrimary;
+    },
+
+    async load(id) {
+      if (id !== RESOLVED_RUNTIME_MAP_ID || !state.isPrimary) return;
+
+      const maps = await Promise.all(
+        allUsages(state).map(async (usage) =>
+          demoSpecifiers(usage.alias, usage.src, await enumerate(usage.src))
+        )
+      );
+
+      const merged = Object.assign({}, ...maps);
+
+      return stripIndent`
+        export const modules = {
+          ${Object.entries(merged)
+            .map(
+              ([specifier, file]) =>
+                `${JSON.stringify(specifier)}: () => import(${JSON.stringify('/@fs' + file)})`
+            )
+            .join(',\n')}
+        };
+      `;
+    },
+
+    vite: {
+      api: { kolay: state },
+      async configResolved(resolvedConfig) {
+        /**
+         * Discover every demos() usage — each aliases its own directory,
+         * the first ("primary") usage serves the shared runtime map.
+         */
+        const states = resolvedConfig.plugins
+          .filter((plugin) => plugin.name === name)
+          .map((plugin) => plugin.api?.kolay)
+          .filter(Boolean);
+
+        if (states.length > 1) {
+          const usages = states.map((usageState) => usageState.options);
+
+          states.forEach((usageState, i) => {
+            usageState.usages = usages;
+            usageState.isPrimary = i === 0;
+          });
+
+          const aliases = usages.map((usage) => usage.alias);
+          const duplicates = aliases.filter((alias, i) => aliases.indexOf(alias) !== i);
+
+          if (duplicates.length > 0) {
+            throw new Error(
+              `Every demos() usage needs its own \`as\`. Duplicated: ${[...new Set(duplicates)].join(', ')}`
+            );
+          }
+        }
+
+        resolvedConfig.server ||= {};
+        resolvedConfig.server.fs ||= {};
+        resolvedConfig.server.fs.allow ||= [];
+        resolvedConfig.server.fs.allow.push(state.options.src);
+
+        specifiers = demoSpecifiers(
+          state.options.alias,
+          state.options.src,
+          await enumerate(state.options.src)
+        );
+      },
+    },
+  };
+};

--- a/src/build/plugins/demos.js
+++ b/src/build/plugins/demos.js
@@ -147,6 +147,10 @@ export const demos = (state) => {
 
   return {
     name,
+    // '#'-style specifiers otherwise hit the bundler's native
+    // subpath-imports resolution (package.json#imports) first, which
+    // errors hard on unknown specifiers
+    enforce: 'pre',
 
     resolveId(id) {
       // the shared runtime map, served by the primary usage

--- a/src/build/plugins/demos.test.ts
+++ b/src/build/plugins/demos.test.ts
@@ -1,0 +1,57 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { demoSpecifiers, parseDemosArgs } from './demos.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe('parseDemosArgs', () => {
+  it('accepts a path and an alias', () => {
+    expect(parseDemosArgs(here, { as: 'demos/foo' })).toEqual({
+      src: here,
+      alias: 'demos/foo',
+    });
+  });
+
+  it('accepts a file URL (import.meta.resolve style)', () => {
+    expect(parseDemosArgs(`file://${here}`, { as: 'demos/foo' })).toEqual({
+      src: here,
+      alias: 'demos/foo',
+    });
+  });
+
+  it.each([
+    [undefined, undefined, /requires a path/],
+    [here, undefined, /requires an `as` option/],
+    [here, { as: '' }, /requires an `as` option/],
+    [here, { as: 'virtual:demos/foo' }, /should not include the 'virtual:' prefix/],
+    [here, { as: '/demos' }, /should not start or end with '\/'/],
+    [here, { as: 'demos/' }, /should not start or end with '\/'/],
+    [join(here, 'does-not-exist'), { as: 'demos/foo' }, /path does not exist/],
+  ])('rejects %s / %o', (src, options, message) => {
+    // @ts-expect-error deliberately wrong shapes
+    expect(() => parseDemosArgs(src, options)).toThrow(message);
+  });
+});
+
+describe('demoSpecifiers', () => {
+  it('maps each file, and lets index files provide their directory', () => {
+    const map = demoSpecifiers('demos/foo', '/abs', [
+      'button.gjs',
+      'index.gjs',
+      'forms/input.gts',
+      'forms/index.gjs',
+    ]);
+
+    expect(map).toEqual({
+      'virtual:demos/foo/button': '/abs/button.gjs',
+      'virtual:demos/foo/index': '/abs/index.gjs',
+      'virtual:demos/foo': '/abs/index.gjs',
+      'virtual:demos/foo/forms/input': '/abs/forms/input.gts',
+      'virtual:demos/foo/forms/index': '/abs/forms/index.gjs',
+      'virtual:demos/foo/forms': '/abs/forms/index.gjs',
+    });
+  });
+});

--- a/src/build/plugins/demos.test.ts
+++ b/src/build/plugins/demos.test.ts
@@ -8,28 +8,34 @@ import { demoSpecifiers, parseDemosArgs } from './demos.js';
 const here = dirname(fileURLToPath(import.meta.url));
 
 describe('parseDemosArgs', () => {
-  it('accepts a path and an alias', () => {
-    expect(parseDemosArgs(here, { as: 'demos/foo' })).toEqual({
+  it('accepts a path and a specifier', () => {
+    expect(parseDemosArgs(here, { as: '#demos/foo' })).toEqual({
       src: here,
-      alias: 'demos/foo',
+      alias: '#demos/foo',
     });
   });
 
   it('accepts a file URL (import.meta.resolve style)', () => {
-    expect(parseDemosArgs(`file://${here}`, { as: 'demos/foo' })).toEqual({
+    expect(parseDemosArgs(`file://${here}`, { as: '#demos/foo' })).toEqual({
       src: here,
-      alias: 'demos/foo',
+      alias: '#demos/foo',
     });
+  });
+
+  it('uses any valid import URI verbatim', () => {
+    expect(parseDemosArgs(here, { as: 'demo-kit' }).alias).toBe('demo-kit');
+    expect(parseDemosArgs(here, { as: '@scope/demos' }).alias).toBe('@scope/demos');
   });
 
   it.each([
     [undefined, undefined, /requires a path/],
     [here, undefined, /requires an `as` option/],
     [here, { as: '' }, /requires an `as` option/],
-    [here, { as: 'virtual:demos/foo' }, /should not include the 'virtual:' prefix/],
-    [here, { as: '/demos' }, /should not start or end with '\/'/],
-    [here, { as: 'demos/' }, /should not start or end with '\/'/],
-    [join(here, 'does-not-exist'), { as: 'demos/foo' }, /path does not exist/],
+    [here, { as: './demos' }, /valid import URI/],
+    [here, { as: '/demos' }, /valid import URI/],
+    [here, { as: 'demos/' }, /valid import URI/],
+    [here, { as: 'demos foo' }, /valid import URI/],
+    [join(here, 'does-not-exist'), { as: '#demos/foo' }, /path does not exist/],
   ])('rejects %s / %o', (src, options, message) => {
     // @ts-expect-error deliberately wrong shapes
     expect(() => parseDemosArgs(src, options)).toThrow(message);
@@ -38,7 +44,7 @@ describe('parseDemosArgs', () => {
 
 describe('demoSpecifiers', () => {
   it('maps each file, and lets index files provide their directory', () => {
-    const map = demoSpecifiers('demos/foo', '/abs', [
+    const map = demoSpecifiers('#demos/foo', '/abs', [
       'button.gjs',
       'index.gjs',
       'forms/input.gts',
@@ -46,12 +52,12 @@ describe('demoSpecifiers', () => {
     ]);
 
     expect(map).toEqual({
-      'virtual:demos/foo/button': '/abs/button.gjs',
-      'virtual:demos/foo/index': '/abs/index.gjs',
-      'virtual:demos/foo': '/abs/index.gjs',
-      'virtual:demos/foo/forms/input': '/abs/forms/input.gts',
-      'virtual:demos/foo/forms/index': '/abs/forms/index.gjs',
-      'virtual:demos/foo/forms': '/abs/forms/index.gjs',
+      '#demos/foo/button': '/abs/button.gjs',
+      '#demos/foo/index': '/abs/index.gjs',
+      '#demos/foo': '/abs/index.gjs',
+      '#demos/foo/forms/input': '/abs/forms/input.gts',
+      '#demos/foo/forms/index': '/abs/forms/index.gjs',
+      '#demos/foo/forms': '/abs/forms/index.gjs',
     });
   });
 });

--- a/src/build/plugins/index.js
+++ b/src/build/plugins/index.js
@@ -1,4 +1,4 @@
 export { generateTypeDocJSON } from './api-docs/typedoc.js';
-export { apiDocs, docs } from './combined.js';
+export { apiDocs, demos, docs } from './combined.js';
 export { gitRef } from './git-ref.js';
 export { packageTypes, virtualFile } from './helpers.js';

--- a/src/build/plugins/setup.js
+++ b/src/build/plugins/setup.js
@@ -275,6 +275,12 @@ export const setup = (state) => {
    */
   let hasApiDocs = true;
 
+  /**
+   * Same idea for demos(): when absent, an empty 'kolay/demos:virtual'
+   * keeps the generated setupKolay's import working.
+   */
+  let hasDemos = true;
+
   return {
     name: 'kolay:setup',
     vite: {
@@ -283,6 +289,7 @@ export const setup = (state) => {
         baseUrl = resolvedConfig.base;
         isBuild = resolvedConfig.command === 'build';
         hasApiDocs = resolvedConfig.plugins.some((plugin) => plugin.name === 'kolay:apidocs');
+        hasDemos = resolvedConfig.plugins.some((plugin) => plugin.name === 'kolay:demos');
 
         /**
          * Discover every docs() usage in this config — the plugin may be
@@ -416,6 +423,14 @@ export const setup = (state) => {
         `,
       },
       {
+        importPath: 'kolay/demos:virtual',
+        // dormant whenever a demos() plugin provides the real thing
+        when: () => !hasDemos,
+        content: stripIndent`
+          export const modules = {};
+        `,
+      },
+      {
         importPath: 'kolay/setup',
         content: stripIndent`
           import { getOwner, setOwner } from '@ember/owner';
@@ -462,9 +477,10 @@ export const setup = (state) => {
             //             :(
             //             So the whole strategy / benefit of setupKolay is
             //             .... much less useful than originally planned
-            let [apiDocs, meta] = await Promise.all([
+            let [apiDocs, meta, demos] = await Promise.all([
               import('kolay/api-docs:virtual'),
               import('kolay/compiled-docs:virtual'),
+              import('kolay/demos:virtual'),
             ]);
 
             // every group's docs module, loaded in parallel
@@ -474,6 +490,8 @@ export const setup = (state) => {
               apiDocs,
               compiledDocs,
               ...options,
+              // demos() aliases resolve automatically; explicit modules win
+              modules: { ...demos.modules, ...(options?.modules ?? {}) },
             });
 
 

--- a/src/build/vite.js
+++ b/src/build/vite.js
@@ -1,4 +1,4 @@
-import { apiDocs as _apiDocs, docs as _docs } from './plugins/index.js';
+import { apiDocs as _apiDocs, demos as _demos, docs as _docs } from './plugins/index.js';
 
 /**
  * The markdown-docs plugin. One usage per group:
@@ -19,3 +19,19 @@ export function docs(groupName, options) {
  * The api-docs plugin (requires `docs` to also be used).
  */
 export const apiDocs = _apiDocs.vite;
+
+/**
+ * The demos plugin: aliases a directory of demo components so code
+ * fences can import them —
+ *
+ * `demos(import.meta.resolve('./demos'), { as: 'demos/foo' })` enables
+ * `import ... from 'virtual:demos/foo/<demo>'` in live codefences.
+ * The runtime compiler learns the aliases automatically, so `.md`
+ * fences need no `modules` configuration.
+ *
+ * @param {string} src - where the demos live (a path, or an `import.meta.resolve()`d URL)
+ * @param {{ as: string }} options
+ */
+export function demos(src, options) {
+  return _demos.vite([src, options]);
+}

--- a/src/build/vite.js
+++ b/src/build/vite.js
@@ -24,8 +24,8 @@ export const apiDocs = _apiDocs.vite;
  * The demos plugin: aliases a directory of demo components so code
  * fences can import them —
  *
- * `demos(import.meta.resolve('./demos'), { as: 'demos/foo' })` enables
- * `import ... from 'virtual:demos/foo/<demo>'` in live codefences.
+ * `demos(import.meta.resolve('./demos'), { as: '#demos/foo' })` enables
+ * `import ... from '#demos/foo/<demo>'` in live codefences.
  * The runtime compiler learns the aliases automatically, so `.md`
  * fences need no `modules` configuration.
  *

--- a/test-apps/multiple-docs-routes/guides/getting-started/using-demos.md
+++ b/test-apps/multiple-docs-routes/guides/getting-started/using-demos.md
@@ -3,7 +3,7 @@
 A runtime-compiled page whose live fence imports a shared demo:
 
 ```gjs live
-import Hello from "virtual:demos/kit/hello";
+import Hello from "#demos/kit/hello";
 
 <template><Hello /></template>
 ```

--- a/test-apps/multiple-docs-routes/guides/getting-started/using-demos.md
+++ b/test-apps/multiple-docs-routes/guides/getting-started/using-demos.md
@@ -1,0 +1,9 @@
+# Guides demo
+
+A runtime-compiled page whose live fence imports a shared demo:
+
+```gjs live
+import Hello from "virtual:demos/kit/hello";
+
+<template><Hello /></template>
+```

--- a/test-apps/multiple-docs-routes/shared-demos/hello.gjs
+++ b/test-apps/multiple-docs-routes/shared-demos/hello.gjs
@@ -1,0 +1,3 @@
+<template>
+  <p data-demo="hello">Hello from a shared demo!</p>
+</template>

--- a/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
+++ b/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
@@ -1,6 +1,10 @@
-import { currentURL, visit } from "@ember/test-helpers";
+import { currentURL, render, visit } from "@ember/test-helpers";
 import { module, test } from "qunit";
-import { setupApplicationTest } from "ember-qunit";
+import { setupApplicationTest, setupRenderingTest } from "ember-qunit";
+
+// build-time resolution of a demos() alias: this import is compiled
+// like any other module in the app graph
+import Hello from "virtual:demos/kit/hello";
 
 import { docsManager } from "kolay";
 import {
@@ -37,6 +41,13 @@ module("Multiple docs routes", function (hooks) {
 
     assert.strictEqual(guidesMeta.docsPath, "test-apps/multiple-docs-routes/guides");
     assert.notOk("package" in guidesMeta, "no meta.jsonc, no mixed-in content");
+  });
+
+  test("a runtime-compiled fence imports a demos() alias, with no modules config", async function (assert) {
+    await visit("/help/getting-started/using-demos.md");
+
+    assert.dom("[data-page-error]").doesNotExist();
+    assert.dom("[data-demo=hello]").containsText("Hello from a shared demo!");
   });
 
   test("a co-located page renders from the root mount", async function (assert) {
@@ -95,5 +106,15 @@ module("Multiple docs routes", function (hooks) {
 
     assert.strictEqual(currentURL(), "/demos/components/buttons");
     assert.dom("h1").containsText("Buttons demo");
+  });
+});
+
+module("demos() | build-time", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("app code imports a demos() alias directly", async function (assert) {
+    await render(<template><Hello /></template>);
+
+    assert.dom("[data-demo=hello]").containsText("Hello from a shared demo!");
   });
 });

--- a/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
+++ b/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
@@ -4,7 +4,7 @@ import { setupApplicationTest, setupRenderingTest } from "ember-qunit";
 
 // build-time resolution of a demos() alias: this import is compiled
 // like any other module in the app graph
-import Hello from "virtual:demos/kit/hello";
+import Hello from "#demos/kit/hello";
 
 import { docsManager } from "kolay";
 import {

--- a/test-apps/multiple-docs-routes/types/demos.d.ts
+++ b/test-apps/multiple-docs-routes/types/demos.d.ts
@@ -1,5 +1,5 @@
 // the demos() aliases this app declares in vite.config.mjs
-declare module "virtual:demos/kit/hello" {
+declare module "#demos/kit/hello" {
   import type { TOC } from "@ember/component/template-only";
 
   const Hello: TOC<{ Element: HTMLParagraphElement }>;

--- a/test-apps/multiple-docs-routes/types/virtual-demos.d.ts
+++ b/test-apps/multiple-docs-routes/types/virtual-demos.d.ts
@@ -1,0 +1,8 @@
+// the demos() aliases this app declares in vite.config.mjs
+declare module "virtual:demos/kit/hello" {
+  import type { TOC } from "@ember/component/template-only";
+
+  const Hello: TOC<{ Element: HTMLParagraphElement }>;
+
+  export default Hello;
+}

--- a/test-apps/multiple-docs-routes/vite.config.mjs
+++ b/test-apps/multiple-docs-routes/vite.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import { extensions, ember } from "@embroider/vite";
 import { babel } from "@rollup/plugin-babel";
-import { docs } from "kolay/vite";
+import { demos, docs } from "kolay/vite";
 
 export default defineConfig({
   plugins: [
@@ -13,6 +13,8 @@ export default defineConfig({
       // only THIS usage's .gjs.md files get <Callout> in scope
       scope: `import { Callout } from '#app/components/callout.gjs';`,
     }),
+    // fences (runtime and build-time) import these as 'virtual:demos/kit/*'
+    demos(import.meta.resolve("./shared-demos", import.meta.url), { as: "demos/kit" }),
     ember(),
     babel({
       babelHelpers: "runtime",

--- a/test-apps/multiple-docs-routes/vite.config.mjs
+++ b/test-apps/multiple-docs-routes/vite.config.mjs
@@ -13,8 +13,8 @@ export default defineConfig({
       // only THIS usage's .gjs.md files get <Callout> in scope
       scope: `import { Callout } from '#app/components/callout.gjs';`,
     }),
-    // fences (runtime and build-time) import these as 'virtual:demos/kit/*'
-    demos(import.meta.resolve("./shared-demos", import.meta.url), { as: "demos/kit" }),
+    // fences (runtime and build-time) import these as '#demos/kit/*'
+    demos(import.meta.resolve("./shared-demos", import.meta.url), { as: "#demos/kit" }),
     ember(),
     babel({
       babelHelpers: "runtime",


### PR DESCRIPTION
```js
// vite.config.js
import { demos, docs } from "kolay/vite";

demos(import.meta.resolve("./demos"), { as: "#demos/foo" });
```

```gjs
// any live codefence — .md or .gjs.md
import Example from '#demos/foo/example';

<template><Example /></template>
```

- The `as` is the import specifier, used **verbatim** — any valid import URI works (validation rejects relative/absolute paths, trailing `/`, whitespace). The `#` prefix (Node's subpath-import convention) is the documented recommendation: unmistakably not-an-npm-package. Every file under the path is importable as `<as>/<file>` (extensions dropped; an `index` file provides its directory: `<as>`, `<as>/<dir>`).
- **`.gjs.md` fences** resolve through the build like any module. **`.md` fences** work with *no configuration*: the plugin serves a `kolay/demos:virtual` map of every specifier, and the generated `setupKolay` merges it beneath the user's `modules` (explicit entries win). When no `demos()` is present, `docs()` serves an empty fallback, so `setupKolay` is unchanged for existing apps.
- The plugin is `enforce: 'pre'`: `#`-style ids otherwise hit the bundler's native `package.json#imports` resolution first, which errors hard on unknown specifiers.
- Multiple usages compose, each with its own `as` (duplicates error at config time). Importing something that doesn't exist under a declared specifier errors with the list of what does.

**Docs**: new Authoring → Sharing demos page — deliberately a runtime-compiled `.md` page whose live example imports a real demo from this repo, so the site itself proves the automatic wiring. Cross-linked from Code fences → providing things to demos. (Enabling co-located `.md` pages exposed that the docs-app's registry glob eagerly imported plain `.md` as JS — it now matches only `gjs.md`/`gts.md`.)

**Tests**: 12 new vitest cases (import-URI validation, verbatim aliases, specifier mapping with index folding); the multiple-docs-routes test-app gains a `shared-demos/` fixture with a runtime `.md` fence test (no `modules` config) and a direct build-time import in app code (renamed its test file to `.gts` for `<template>`); the docs-app asserts the live counter renders. Full: vitest 130/130, test-app 11/11, docs-app 51/51, lint 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)