### PR TITLE
Install docs: how to try unreleased kolay from the dist branch

### DIFF
--- a/docs-app/src/templates/install/index.gjs.md
+++ b/docs-app/src/templates/install/index.gjs.md
@@ -28,6 +28,31 @@ pnpm add kolay
 
 [^type-module]: this library sets `type: module` in its `package.json`, which for ember projects means that it requires vite.
 
+<details>
+<summary>Trying unreleased changes (the <code>dist</code> branch)</summary>
+
+Every push to `main` publishes the built package contents to the [`dist` branch](https://github.com/universal-ember/kolay/tree/dist), so unreleased changes can be tried without waiting for a release:
+
+```bash
+pnpm add kolay@github:universal-ember/kolay#dist
+```
+
+In a workspace where other packages also depend on `kolay` (or to keep your declared semver range untouched), use an override instead, in the root `package.json`:
+
+```jsonc
+{
+  "pnpm": {
+    "overrides": {
+      "kolay": "github:universal-ember/kolay#dist",
+    },
+  },
+}
+```
+
+The install resolves the branch to its current commit and pins that in your lockfile — to pick up newer changes later, run `pnpm update kolay` (or re-run the install after removing the lockfile entry).
+
+</details>
+
 ### Use Markdown
 
 - from any folder, any project (good for monorepos)


### PR DESCRIPTION
Adds a collapsed `<details>` under the **Install** section of the install page explaining how to try unreleased kolay before a release: every push to `main` publishes the built package contents to the [`dist` branch](https://github.com/universal-ember/kolay/tree/dist) (via `push-dist.yml`), so it's installable as `kolay@github:universal-ember/kolay#dist` — plus the `pnpm.overrides` variant for workspaces with multiple kolay consumers.

This is exactly the mechanism universal-ember/ember-primitives#794 uses to preview the current plugin rework, so it seemed worth documenting where people install kolay.

Verified rendered locally in the docs-app (collapsed by default; both code fences highlight; the dist-branch link works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update:** also styles authored `<details>` site-wide — pico floats the summary chevron to the container's far edge (a full line-width from the text on wide pages), so folds read as plain prose. Now they're boxed with the caret seated next to the summary text, separator when open; pico-token-derived so light/dark both work.
