### PR TITLE
Top-level scoped mounts register the real route name ('page', not 'application.page')

### DIFF
--- a/src/browser/router.ts
+++ b/src/browser/router.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/owner';
 
-import { groupNameForRoute, registerScopedRoute } from './scoped-routes.ts';
+import { groupNameForRoute, registerScopedRoute, scopedRouteNameFor } from './scoped-routes.ts';
 import { docsManager } from './services/docs.ts';
 
 import type { RouterDSL } from '@ember/-internals/routing';
@@ -65,11 +65,7 @@ export function addRoutes(
   context.route('page', { path: '/*page' }, function () {});
 
   if (groupName) {
-    // `parent` is the surrounding route's full name (set by ember's DSL),
-    // so this is the wildcard route's full name.
-    const routeName = context.parent ? `${context.parent}.page` : 'page';
-
-    registerScopedRoute(routeName, groupName);
+    registerScopedRoute(scopedRouteNameFor(context.parent), groupName);
   }
 }
 

--- a/src/browser/scoped-routes.test.ts
+++ b/src/browser/scoped-routes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+
+import { scopedRouteNameFor } from './scoped-routes.js';
+
+describe('scopedRouteNameFor', () => {
+  test('a top-level mount: ember reports the map root as parent "application"', () => {
+    expect(scopedRouteNameFor('application')).toBe('page');
+  });
+
+  test("a nested mount uses the surrounding route's full name", () => {
+    expect(scopedRouteNameFor('help')).toBe('help.page');
+    expect(scopedRouteNameFor('help.nested')).toBe('help.nested.page');
+  });
+
+  test('no parent at all behaves like the root', () => {
+    expect(scopedRouteNameFor(null)).toBe('page');
+    expect(scopedRouteNameFor(undefined)).toBe('page');
+  });
+});

--- a/src/browser/scoped-routes.ts
+++ b/src/browser/scoped-routes.ts
@@ -10,6 +10,21 @@
  */
 const scopedRouteGroups = new Map<string, string>();
 
+/**
+ * The full name of the wildcard route `addRoutes` creates, given the
+ * surrounding route's full name (the DSL's `parent`).
+ *
+ * At the top of the router map, ember's DSL reports `parent` as
+ * 'application', which its own getFullName treats as "no prefix" —
+ * mirror that, or a top-level scoped mount would register as
+ * 'application.page' while the real route is 'page'.
+ */
+export function scopedRouteNameFor(parent: string | null | undefined): string {
+  const prefix = parent === 'application' ? null : parent;
+
+  return prefix ? `${prefix}.page` : 'page';
+}
+
 export function registerScopedRoute(routeName: string, groupName: string): void {
   scopedRouteGroups.set(routeName, groupName);
 }


### PR DESCRIPTION
`addRoutes(this, 'docs')` at the top level of the router map never activated: ember's DSL reports the map root's `parent` as `'application'`, which ember's own `getFullName` treats as "no prefix" — kolay registered the mount at `'application.page'` while the created route is named `'page'`, so `#activeScopedMount` never matched and the docs service silently fell back to the first group (`Home`).

The route-name computation moves into `scoped-routes.ts` (`scopedRouteNameFor`) where it's a pure function with unit tests: `'application'` → `page`, `'help'` → `help.page`, `null`/`undefined` → `page`.

Found while migrating limber's tutorial app (a root-mounted `docs` group preserving its existing URL space) onto the reworked plugin API — kolay's test-apps only exercise *nested* scoped mounts.

Also worth knowing (not fixed here): a relative `docs()` `src` (e.g. `'public/docs'`) produces broken `/@fs` imports in the virtual module — `'/@fs' + join('public/docs', …)` = `/@fspublic/docs/…`. `import.meta.resolve()` works; happy to fix resolution against the config root in a follow-up if you want relative paths supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
