### PR TITLE
match paths case-insensitively in the browser router

### DIFF
--- a/src/browser/is-active.test.ts
+++ b/src/browser/is-active.test.ts
@@ -30,6 +30,13 @@ describe('isActive', () => {
     expect(isActive(page('/Documentation/x'), '/Documentation/x.md')).toBe(true);
   });
 
+  test('is insensitive to casing, in the path and in the .md extension', () => {
+    expect(isActive(page('/Documentation/x.md'), '/documentation/x.md')).toBe(true);
+    expect(isActive(page('/Documentation/x.md'), '/DOCUMENTATION/X')).toBe(true);
+    expect(isActive(page('/Documentation/x.md'), '/Documentation/x.MD')).toBe(true);
+    expect(isActive(page('/Documentation/x.md'), '/documentation/y.md')).toBe(false);
+  });
+
   test('does not treat a sibling with a shared prefix as active', () => {
     expect(isActive(page('/Documentation/x.md'), '/Documentation/x-and-more.md')).toBe(false);
   });

--- a/src/browser/is-active.ts
+++ b/src/browser/is-active.ts
@@ -1,3 +1,5 @@
+import { equalsIgnoreCase } from './path-matching.ts';
+
 import type { Collection, Page } from '../types.ts';
 
 /**
@@ -32,5 +34,5 @@ export function isActive(item: Page | Collection, currentURL: string | null | un
 
   const [current = ''] = currentURL?.split(/[?#]/) ?? [];
 
-  return current.replace(/\.md$/, '') === subPath.replace(/\.md$/, '');
+  return equalsIgnoreCase(current.replace(/\.md$/i, ''), subPath.replace(/\.md$/i, ''));
 }

--- a/src/browser/path-matching.ts
+++ b/src/browser/path-matching.ts
@@ -1,0 +1,11 @@
+/**
+ * URLs are conventionally case-insensitive; path/route matching in this
+ * library follows that convention rather than treating paths as opaque,
+ * case-sensitive strings.
+ *
+ * No imports here on purpose — `is-active.ts` is deliberately kept
+ * Ember-free and needs this helper too.
+ */
+export function equalsIgnoreCase(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}

--- a/src/browser/router.ts
+++ b/src/browser/router.ts
@@ -114,10 +114,11 @@ export function handlePotentialIndexVisit(context: object, transition: Transitio
           parent?.localName,
         ];
 
-  const groupName = candidates.find(
-    (candidate): candidate is string =>
-      typeof candidate === 'string' && docs.availableGroups.includes(candidate)
-  );
+  const groupName = candidates
+    .map((candidate) =>
+      typeof candidate === 'string' ? docs.canonicalGroupName(candidate) : undefined
+    )
+    .find((match): match is string => match !== undefined);
 
   if (!groupName) return;
 

--- a/src/browser/services/docs.ts
+++ b/src/browser/services/docs.ts
@@ -7,6 +7,7 @@ import { createStore } from 'ember-primitives/store';
 import { type ModuleMap, type ScopeMap, setupCompiler } from 'ember-repl';
 
 import { rebaseAuthoredLinks } from '../../rebase-links.js';
+import { equalsIgnoreCase } from '../path-matching.ts';
 import { groupNameForRoute, indexRouteNameFor, routeNameForGroup } from '../scoped-routes.ts';
 import { APIDocs, CommentQuery } from '../typedoc/renderer.gts';
 import { ComponentSignature } from '../typedoc/signature/component.gts';
@@ -257,10 +258,17 @@ class DocsService {
 
     if (!first) return this.availableGroups[0];
 
-    if (!this.availableGroups.includes(first)) return this.availableGroups[0];
-
-    return first;
+    return this.canonicalGroupName(first) ?? this.availableGroups[0];
   }
+
+  /**
+   * The manifest's own casing for a group name, matched case-insensitively —
+   * URLs are conventionally case-insensitive, but hrefs / `urlFor` need the
+   * manifest's casing.
+   */
+  canonicalGroupName = (name: string): string | undefined => {
+    return this.availableGroups.find((candidate) => equalsIgnoreCase(candidate, name));
+  };
 
   /**
    * The scoped mount (`addRoutes(context, groupName)`) the current route
@@ -432,7 +440,7 @@ class DocsService {
   groupForURL = (url: string): false | string => {
     for (const groupName of this.availableGroups) {
       const group = this.groupFor(groupName);
-      const page = group.list.find((page) => page.appRelativePath === url);
+      const page = group.list.find((page) => equalsIgnoreCase(page.appRelativePath, url));
 
       if (page) {
         return groupName;
@@ -449,7 +457,9 @@ class DocsService {
    */
   findByPath = (path: string) => {
     return this.pages.find(
-      (page) => page.appRelativePath === path || page.appRelativePath === path + '.md'
+      (page) =>
+        equalsIgnoreCase(page.appRelativePath, path) ||
+        equalsIgnoreCase(page.appRelativePath, path + '.md')
     );
   };
 }

--- a/test-apps/custom-root-url/tests/index-redirect-test.ts
+++ b/test-apps/custom-root-url/tests/index-redirect-test.ts
@@ -38,4 +38,20 @@ module("Group index redirects under a custom rootURL", function (hooks) {
       "trailing slash doesn't break the redirect",
     );
   });
+
+  test("visiting a group root with different casing still redirects to its first page", async function (assert) {
+    await visit("/home");
+    assert.strictEqual(
+      currentURL(),
+      "/my-folder-name/bar.md",
+      "the group name is matched case-insensitively",
+    );
+
+    await visit("/DOCUMENTATION");
+    assert.strictEqual(
+      currentURL(),
+      "/Documentation/sub-folder/lonely-page.md",
+      "the group name is matched case-insensitively",
+    );
+  });
 });

--- a/test-apps/custom-root-url/tests/nav-active-state-test.ts
+++ b/test-apps/custom-root-url/tests/nav-active-state-test.ts
@@ -43,6 +43,25 @@ module("Nav active state under a custom rootURL", function (hooks) {
       .hasClass("active", "the current page's link is active");
   });
 
+  test("a page is rendered and marked active when visited with different casing", async function (assert) {
+    await visit("/documentation/sub-folder/LONELY-PAGE.md");
+    await waitFor(`${PAGE_NAV} a`);
+    await waitFor("h1");
+
+    assert.dom("h1").hasText("Please Visit Me!", "the page's content is rendered");
+
+    assert
+      .dom(`${GROUP_NAV} a[href="/my-github-project/Documentation"]`)
+      .hasClass("active", "the selected group's link is active, in its canonical casing");
+    assert
+      .dom(`${GROUP_NAV} a[href="/my-github-project/Home"]`)
+      .doesNotHaveClass("active", "the other group's link is not active");
+
+    assert
+      .dom(`${PAGE_NAV} a[href="/my-github-project/Documentation/sub-folder/lonely-page.md"]`)
+      .hasClass("active", "the current page's link is active, in its canonical casing");
+  });
+
   test("the current page is marked active when visited without the .md extension", async function (assert) {
     await visit("/Documentation/sub-folder/lonely-page");
     await waitFor(`${PAGE_NAV} a`);

--- a/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
+++ b/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
@@ -82,6 +82,13 @@ module("Multiple docs routes", function (hooks) {
     assert.dom("h1").containsText("Guides usage");
   });
 
+  test("a page renders from a scoped mount regardless of the URL's casing", async function (assert) {
+    await visit("/help/getting-started/INTRO.md");
+
+    assert.dom("[data-page-error]").doesNotExist();
+    assert.dom("h1").containsText("Guides intro");
+  });
+
   test("inside a scoped mount, nav links use the mount's URL space", async function (assert) {
     await visit("/help/getting-started/intro.md");
 


### PR DESCRIPTION
URLs are conventionally case-insensitive, but group/page lookups in DocsService and the index-visit redirect used exact-case comparisons, so visiting e.g. /documentation instead of /Documentation silently fell back to the default group or failed to resolve a page.