### PR TITLE
fix(browser): shadow-DOM-isolate gmd live demos by default

### DIFF
--- a/src/browser/services/docs.ts
+++ b/src/browser/services/docs.ts
@@ -74,6 +74,11 @@ export function compilerOptions({
       gmd: {
         scope,
         ...md,
+        // Style-isolate every live demo in its own shadow root (restores the
+        // auto-wrapping ember-repl 6.x used to do by default before its 8.x
+        // rewrite dropped the concept). Individual code fences can still
+        // opt out with a `no-shadow` meta flag.
+        ShadowComponent: true,
       },
       hbs: {
         scope,


### PR DESCRIPTION
## Summary

`compilerOptions()`'s `gmd` options now default `ShadowComponent` to `true`,
so every live glimdown demo renders inside its own shadow root instead of
leaking styles into/out of the surrounding docs UI. This restores
auto-wrapping behavior that predates `ember-repl`'s 8.x rewrite (see the
companion PR against `repl-sdk`:
https://github.com/NullVoxPopuli/limber/pull/2206, which teaches the gmd
compiler to actually honor a boolean `ShadowComponent` — this kolay change
has no effect until that lands, since `ShadowComponent` isn't consumed
downstream yet). Individual code fences can opt out via a `no-shadow` meta
flag.

We're carrying this as a `pnpm patch` in downstream consumer
[carbon-components-ember](https://github.com/carbon-design-system/carbon-components-ember).

The `isIndex()` fix that was originally bundled here has been split out to
#356 per review feedback.

## Test plan

- [x] `pnpm lint:js` / `pnpm lint:prettier` / `pnpm lint:types` pass
- [x] `pnpm build` succeeds