### PR TITLE
fix(browser): isIndex() recognizes index.md, not just extension-less index

### DIFF
--- a/docs-app/tests/kolay/is-index-test.ts
+++ b/docs-app/tests/kolay/is-index-test.ts
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+
+import { isIndex } from 'kolay';
+
+import type { Collection, Page } from 'kolay';
+
+function page(path: string): Page {
+  return {
+    path,
+    appRelativePath: path,
+    name: path,
+    groupName: 'Documentation',
+    cleanedName: path,
+  };
+}
+
+function collection(path: string, pages: (Page | Collection)[]): Collection {
+  return { path, appRelativePath: path, name: path, pages };
+}
+
+module('isIndex', function () {
+  test('matches an extension-less index path', function (assert) {
+    assert.true(isIndex(page('/Documentation/sub-folder/index')));
+  });
+
+  test('matches an index.md path', function (assert) {
+    assert.true(isIndex(page('/Documentation/sub-folder/index.md')));
+  });
+
+  test('does not match a non-index page', function (assert) {
+    assert.false(isIndex(page('/Documentation/sub-folder/x.md')));
+  });
+
+  test('a collection is never an index, regardless of its path', function (assert) {
+    assert.false(isIndex(collection('/Documentation/index', [])));
+  });
+});

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -11,7 +11,7 @@ export function isCollection(x: Page | Collection): x is Collection {
 export function isIndex(x: Page | Collection) {
   if (isCollection(x)) return false;
 
-  return x.path.endsWith('index');
+  return x.path.replace(/\.md$/, '').endsWith('index');
 }
 
 export function getIndexPage(x: Collection): Page | undefined {


### PR DESCRIPTION
## Summary

Split out of #355 per review feedback.

`isIndex()` now strips a trailing `.md` extension before checking for an
`index` suffix. Previously only extension-less paths matched, so a page
authored as `index.md` was silently treated as a regular (non-index) page
instead of being recognized as its collection's index.

## Test plan

- [x] added `docs-app/tests/kolay/is-index-test.ts` covering extension-less
      index paths, `index.md` paths, non-index pages, and collections
- [x] `pnpm lint:js` / `pnpm lint:prettier` / `pnpm lint:types` pass
- [x] `pnpm build` succeeds
- [x] `pnpm --filter docs-app test:ember` — 66/66 pass (5 intentionally skipped)