### PR TITLE
Design spec: group path aliases

### DIFF
--- a/docs/superpowers/specs/2026-08-03-group-path-aliases-design.md
+++ b/docs/superpowers/specs/2026-08-03-group-path-aliases-design.md
@@ -1,0 +1,74 @@
+# Group path aliases
+
+Date: 2026-08-03
+
+## Problem
+
+A kolay app's `docs()` config names a "group" (e.g. `docs('Runtime', { src: ... })`), and — in the common "root URL space" mount mode, where a single `addRoutes(this)` call at the router root serves every group off a shared wildcard route — that name becomes the group's top-level URL segment (`/Runtime/...`). Renaming a group today breaks every existing bookmark/external link to it: the old URL segment no longer matches any group, and the page fails to resolve.
+
+This feature lets a `docs()` usage declare the group's old name(s) as aliases, so visiting an old URL redirects to the equivalent URL under the new name.
+
+## Scope
+
+Aliases apply to the group's top-level URL segment in the shared-wildcard "root URL space" mount mode (`addRoutes(this)` called once, unscoped, at the router root — the mode used when multiple groups share the generic `page` route and the URL's first segment names the group).
+
+**Out of scope / limitations:**
+- A *scoped* mount (`addRoutes(this, 'foo-bar')`) has a URL independent of the group name — renaming the group doesn't change its URL, so aliasing is moot there.
+- A dedicated nested mount whose own route path is hardcoded by the consumer (e.g. `this.route('runtime', { path: '/Runtime' }, function () { addRoutes(this) })`, as `docs-app` itself uses) has its URL segment fixed by that hardcoded path string, decided entirely in the consumer's own `router.ts`, before any kolay code runs. `docs()`'s `aliases` option can't affect that; a consumer wanting to preserve an old URL for a dedicated mount manages it via plain Ember routing (keeping/redirecting the old route) themselves.
+- Only the group's top-level name is aliased. Aliasing individual page paths within a group is not covered by this design.
+
+## Config surface
+
+`docs(groupName, options)` gains an `aliases` option:
+
+```js
+docs('Playground', { src: import.meta.resolve('./playground'), aliases: ['Runtime'] })
+
+// a group renamed more than once:
+docs('Playground', { src: import.meta.resolve('./playground'), aliases: ['Runtime', 'Sandbox'] })
+```
+
+- `aliases?: string[]` — old group name(s) that now resolve to this group. No bare-string shorthand; always an array. Defaults to `[]`.
+- Matching is case-insensitive, consistent with existing group-name matching (`equalsIgnoreCase`).
+- An alias colliding with any group's real name, or with another group's alias, is a build-time error naming the conflicting groups — e.g.:
+  > `Alias 'Runtime' (declared on group 'Playground') collides with group 'Runtime'. Alias names must be unique across every group and its aliases.`
+
+## Behavior
+
+Visiting an aliased URL (e.g. `/Runtime/sub/page`, for a group renamed to `Playground` with `aliases: ['Runtime']`) redirects (URL bar changes) to the canonical equivalent (`/Playground/sub/page`), preserving the remainder of the path. A canonical group name never redirects. An unrelated/unknown URL segment (neither a group name nor an alias) is untouched — falls through to existing "not found" handling, unrelated to this feature.
+
+## Build-side data flow
+
+1. `src/build/plugins/docs-args.js`: `DocsOptions` gains `aliases?: string[]`. `parseDocsArgs` passes it onto the group entry: `groups: [{ name, src, aliases }]`.
+2. `src/build/plugins/setup.js`:
+   - `groupSource(group)` threads `group.aliases` into the `enumerateSource` input.
+   - `enumerateSource` includes it on the constructed group: `manifestGroup: { name: displayName, aliases, ...found }`.
+   - A new validation pass (alongside `assertUniqueGroupNames`) collects every group's `aliases` and errors (per the message above) if any alias collides with another group's `name` or another group's `aliases`.
+3. `src/types.ts`: `Manifest['groups'][number]` gains `aliases: string[]` (always present, `[]` when none configured).
+
+This rides the same path every other group property (`name`, `list`, `tree`) already takes from config → `manifestGroup` → the serialized `virtual:kolay/docs/<group>` module → the browser's `Manifest`.
+
+## Runtime resolution & redirect
+
+- **`DocsService.canonicalGroupName(name)`** (`src/browser/services/docs.ts:269`) becomes alias-aware: it matches `name` case-insensitively against each group's `name` **or** any entry in its `aliases`, returning the group's canonical `name`. This is the single source of truth `selectedGroup` and the redirect check both use, so content resolves to the correct group immediately — even in the instant before a redirect transition completes.
+- **`handlePotentialIndexVisit`** (`src/browser/router.ts:78`) gains an additional check, run whenever we're inside the wildcard mount (`parent` exists), before falling through to the existing bare-index-visit logic:
+  1. Take `wildcardParam` (already computed in this function), split off its first path segment.
+  2. If that segment is already an exact (canonical) group name, do nothing further here — existing behavior applies unchanged.
+  3. Otherwise, if `canonicalGroupName(firstSegment)` resolves to some *other* name (the segment matched via an alias, not the canonical name itself), rebuild the path with that first segment replaced by the canonical name — keeping the remainder untouched — and `router.transitionTo(...)` to it, using the same app-relative-path convention the existing index-visit redirect already uses.
+  4. Otherwise (the segment is neither a group name nor an alias), leave it alone.
+- This folds into the existing `handlePotentialIndexVisit` rather than a new opt-in function: every consumer app already calls it from each route's `redirect()` hook (see `docs-app/src/routes/{page,index,runtime,typedoc}.ts`), so alias redirects work automatically with no new call sites and no migration step. A fully-automatic alternative (having `addRoutes()` inject the behavior itself) isn't feasible: `addRoutes` only builds the route map — the `redirect()`/`beforeModel()` hooks live on route classes the consumer authors, outside kolay's control.
+- No changes needed to `hrefFor` / `appRelativeHrefFor` / `groupHrefFor` — they generate links from the manifest's canonical group names, never from URL-derived input, so they can never emit a link to an old alias.
+
+## Testing plan
+
+Following the repo's existing split (vitest for build-side pure logic, qunit — hosted in `docs-app` — for browser-runtime logic):
+
+- **Vitest** (colocated `*.test.ts`):
+  - `docs-args.test.ts` — `parseDocsArgs` passes `aliases` through onto the group entry; defaults to `[]`.
+  - `setup.guard.test.ts` (or a sibling) — the new collision validation throws with a clear message for alias-vs-group-name and alias-vs-alias collisions; passes when aliases are unique.
+- **Qunit** (`docs-app/tests/kolay/*`):
+  - `services/docs-test.ts` — `canonicalGroupName` resolves an alias to its group's canonical name, case-insensitively; unaffected for non-aliased names.
+  - A new test covering `handlePotentialIndexVisit`'s alias-redirect check — visiting `/OldName`, `/OldName/sub/page`, and mixed-case variants transitions to the canonical `/NewName/...` equivalent; a canonical name never redirects; an unrelated unknown segment is untouched.
+  - `docs-app/tests/docs-app/runtime-nav-test.gts` is the closest existing acceptance-style precedent (exercises real navigation/`transitionTo`) — an acceptance test alongside it should render the app and confirm the URL bar updates after visiting an aliased path.
+
+These give TDD anchors for the implementation plan: config parsing → manifest plumbing → `canonicalGroupName` → redirect check, each independently testable before wiring the next.

--- a/docs/superpowers/specs/2026-08-04-path-redirects-design.md
+++ b/docs/superpowers/specs/2026-08-04-path-redirects-design.md
@@ -1,0 +1,88 @@
+# Path redirects via a root kolay config file
+
+Date: 2026-08-04
+
+Supersedes [2026-08-03-group-path-aliases-design.md](./2026-08-03-group-path-aliases-design.md) — that design tied aliases to a specific `docs()` group's config. Review on [PR #359](https://github.com/universal-ember/kolay/pull/359) (maintainer feedback) argued redirects must be a separate concept from `docs()`, since URL mount topology is decided by the consumer's own `router.ts`, not by any `docs()` call. This design replaces the per-group `aliases` option entirely with a single, global, file-driven `redirects` list.
+
+## Problem
+
+Renaming or restructuring a URL path in a kolay-powered docs site breaks every existing bookmark/external link to it. There's currently no way to declare "this old path now lives here" so old links keep working.
+
+## Design goals (from review discussion)
+
+- Redirects must not be tied to a specific `docs()` group or its Vite plugin usage — a mount's URL is decided in the consumer's `router.ts`, independent of which `docs()` call feeds it.
+- Avoid inventing a second parallel config surface. (Rejected: a new `redirects(...)` Vite plugin export living beside `docs()`/`apiDocs()` — still one config file among several, and still couples to the Vite-config layer specifically.)
+- Reuse an existing, well-known pattern for "one project-root config file, several supported formats" — lilconfig (explicitly named in review), the same family of tool ESLint/Stylelint/Prettier use.
+- The whole point of `setupKolay` is "the thing that loads everything the browser runtime needs" — redirects should ride along that, not require any new call-site wiring.
+
+## Config surface
+
+A single root-level config file, discovered via `lilconfig('kolay')`'s default search (no custom loaders — this project has no YAML anywhere today; scope is JS/CJS/MJS/JSON, following existing precedent):
+
+- `kolay.config.js` / `.cjs` / `.mjs`
+- `.kolayrc` / `.kolayrc.json`
+- a `"kolay"` key in `package.json`
+
+Its shape (for now, one key — the file is a general project config, but `redirects` is the only thing it carries until something else needs one):
+
+```js
+// kolay.config.js
+export default {
+  redirects: [
+    { from: 'Runtime/*', to: 'Playground/*' },
+    { from: 'Old/exact/page', to: 'New/exact/page' },
+  ],
+};
+```
+
+- `from` / `to` are plain path prefixes, matched/rewritten whole-segment and case-insensitively (consistent with kolay's existing `equalsIgnoreCase` path-matching convention) — **not** a general glob library. A trailing `/*` means "this segment and everything under it"; without it, the entry matches only that exact path. `from` and `to` must agree on whether they end in `/*` (both, or neither) — a mismatch is a config error.
+- Discovered **once**, at build time (in the primary `docs()` usage's `configResolved`, alongside where `docs()` usages are already discovered in `setup.js`), from `process.cwd()` (matching the `cwd` `setup.js` already uses for `homeSource`/enumeration) upward.
+- The file is the **only** source of redirects. `setupKolay(this, options)` gains no matching option — no merging, no second place to look.
+
+## Validation
+
+At config-load time (build/dev-server start), throw a clear error for:
+- A `redirects` entry whose `from` or `to` isn't a string, or where exactly one of the pair ends in `/*`.
+- Two entries with the same `from` (case-insensitive) — ambiguous, since only one target could apply.
+
+(Overlapping-but-not-identical prefixes, e.g. `Runtime/*` and `Runtime/sub/*`, are not specially detected — entries apply in file order, first match wins. Flagging true overlaps is a possible future enhancement, not needed for v1.)
+
+## Build-side data flow
+
+The metamanifest (`virtual:kolay/compiled-docs`, generated in `setup.js:520-550`) already carries build-time-known, cross-cutting data (`base`) independent of any single `docs()` group — `redirects` belongs there too, not on any per-group manifest entry:
+
+1. `setup.js`: during `configResolved`, run `lilconfig('kolay').search()` once (in the primary usage only — mirrors how `state.isPrimary` already gates other cross-usage work), validate the result (above), default to `[]` if no config file exists.
+2. The generated `kolay/compiled-docs:virtual` module content gains `export const redirects = ${JSON.stringify(redirects)};`, alongside its existing `base`/`groups` exports.
+3. `src/browser/load-compiled-docs.ts`: `MetaManifest` gains `redirects: { from: string; to: string }[]`; `loadCompiledDocs()` threads it straight into the assembled `Manifest`: `manifest: { base: meta.base, redirects: meta.redirects, groups: ... }`.
+4. `src/types.ts`: `Manifest` gains `redirects: { from: string; to: string }[]` (always present, `[]` when no config file / no entries).
+5. `src/browser/virtual.d.ts`: `declare module 'kolay/compiled-docs:virtual'` gains `export const redirects: Array<{ from: string; to: string }>;`.
+
+No changes needed to `docs-args.js`, `docs()`'s options, or `setupKolay`'s options type (`src/browser/virtual/references.d.ts`) — this is intentionally invisible to both.
+
+## Runtime resolution & redirect
+
+- `DocsService` (`src/browser/services/docs.ts`) already receives the full `Manifest` via `PREPARE_DOCS`/`this._docs = compiledDocs.manifest` — `manifest.redirects` is available with no service changes beyond exposing it (or a small `resolveRedirect(path): string | undefined` helper method alongside `findByPath`/`groupForURL`).
+- `handlePotentialIndexVisit` (`src/browser/router.ts:78`) gains a redirect check, run whenever we're inside the wildcard mount (`parent` exists), before its existing bare-index-visit logic:
+  1. Take the current app-relative path (the full remaining wildcard segment, not just its first piece — unlike the superseded design, this isn't scoped to "first segment only").
+  2. Check it against `docs.manifest.redirects` in order: for a `/*`-suffixed `from`, match if the path equals the prefix or starts with `prefix + '/'` (case-insensitive); for a bare `from`, match only on exact equality (case-insensitive).
+  3. On a match, rebuild the path by substituting the matched prefix with `to`'s (preserving whatever remainder follows), and `router.transitionTo(...)` to it — same app-relative-path convention the existing index-visit redirect already uses.
+  4. No match: fall through unchanged to existing behavior.
+- Redirects do not chain: only the first matching entry (checked against the originally-visited path) is applied. If entry A's `to` happens to equal entry B's `from`, visiting a path under A lands on B's `from`, not B's `to` — this keeps behavior predictable and rules out accidental redirect loops from misconfigured entries. Worth a doc comment; not worth a build-time cycle check for v1.
+- This subsumes the previous design's group-rename use case for free (`{ from: 'Runtime/*', to: 'Playground/*' }` is exactly a group rename) while also covering arbitrary path restructuring, and works regardless of mount topology (root wildcard, nested, or scoped) since it operates purely on the resolved URL, not on group names or manifest group membership.
+- No changes needed to `hrefFor` / `appRelativeHrefFor` / `groupHrefFor` — unaffected, as before.
+
+## New dependency
+
+`lilconfig` (small, zero-dependency, widely used for exactly this). No YAML loader added — out of scope per "no existing YAML anywhere in this project."
+
+## Testing plan
+
+- **Vitest** (colocated `*.test.ts`, build-side):
+  - A new test for the `setup.js` config-discovery step: loads `redirects` from each supported file form (`kolay.config.js`, `.kolayrc.json`, `package.json#kolay`); defaults to `[]` when absent.
+  - Validation: throws for non-string `from`/`to`, mismatched trailing-`/*`, and duplicate `from` entries; passes for valid, non-colliding entries.
+- **Qunit** (`docs-app/tests/kolay/*`, browser-side):
+  - A new test for the redirect-matching logic itself (whether exposed as `DocsService.resolveRedirect` or inlined) — `/*`-suffixed prefix matches (including the exact-prefix boundary case), bare exact matches, case-insensitivity, first-match-wins ordering, and "no match" passthrough.
+  - A new router-level test — visiting `/OldPrefix/sub/page` (and mixed-case variants) transitions to the rewritten `/NewPrefix/sub/page`; an exact-match entry redirects only that one path; an unrelated path is untouched.
+  - `docs-app/tests/docs-app/runtime-nav-test.gts` is the closest existing acceptance-style precedent (exercises real navigation/`transitionTo`) — an acceptance test alongside it should render the app with a `kolay.config.js` fixture and confirm the URL bar updates after visiting a redirected path.
+
+This gives TDD anchors for the implementation plan: config discovery/validation → metamanifest plumbing → `Manifest.redirects` → redirect-matching logic → router integration, each independently testable before wiring the next.


### PR DESCRIPTION
## Summary
- Design spec (no implementation yet) for adding an `aliases` option to `docs()`, so a renamed group's old top-level URL segment redirects to its new one.
- Covers config surface, build-side manifest plumbing, browser-side alias-aware resolution + redirect, validation, and a testing plan.
- Opening as a draft purely to collect review comments on the design before writing the implementation plan.

## Test plan
- [ ] N/A — spec-only change, no code yet. Implementation + tests will follow in a subsequent PR once this design is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)