### PR TITLE
feat(browser): add kolay/wrap-demo for shadow-DOM demo isolation

### DIFF
--- a/docs-app/tests/kolay/markdown/wrap-demo-test.gjs
+++ b/docs-app/tests/kolay/markdown/wrap-demo-test.gjs
@@ -1,0 +1,70 @@
+import { setOwner } from '@ember/owner';
+import { find, render, waitUntil } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { use } from 'ember-resources';
+import { Compiled } from 'kolay';
+import { wrapDemo } from 'kolay/wrap-demo';
+
+import { setupKolay } from 'kolay/test-support';
+
+module('Markdown | wrapDemo', function (hooks) {
+  setupRenderingTest(hooks);
+  setupKolay(hooks, { rehypePlugins: [wrapDemo()] });
+
+  async function renderDoc(context, meta) {
+    const doc =
+      `# Hello there\n` +
+      `\n` +
+      `\`\`\`hbs live ${meta}\n` +
+      '<output>\n' +
+      `\tgeneral kenobi\n\n` +
+      '</output>\n' +
+      '```\n';
+
+    class Demo {
+      @use doc = Compiled(() => doc);
+    }
+
+    const state = new Demo();
+
+    setOwner(state, context.owner);
+
+    await render(
+      <template>
+        {{#if state.doc.component}}
+          <state.doc.component />
+        {{/if}}
+      </template>
+    );
+
+    await waitUntil(() => state.doc.isReady);
+
+    return state;
+  }
+
+  test('wraps a live codefence in a shadow root', async function (assert) {
+    await renderDoc(this, '');
+
+    const host = find('kolay-demo-shadow');
+
+    assert.ok(host, 'the placeholder was renamed to the shadow host element');
+
+    await waitUntil(() => host.shadowRoot?.querySelector('output'));
+
+    assert.dom('h1').containsText('Hello there');
+    assert.dom('output').doesNotExist();
+    assert
+      .dom(host.shadowRoot.querySelector('output'))
+      .containsText('general kenobi', 'the demo rendered inside the shadow root');
+  });
+
+  test('a `no-shadow` fence opts out of wrapping', async function (assert) {
+    await renderDoc(this, 'no-shadow');
+
+    assert.dom('h1').containsText('Hello there');
+    assert.dom('kolay-demo-shadow').doesNotExist();
+    assert.dom('output').containsText('general kenobi');
+  });
+});

--- a/src/browser/virtual/references.d.ts
+++ b/src/browser/virtual/references.d.ts
@@ -66,3 +66,43 @@ declare module 'virtual:kolay/docs/*' {
   export const addRoutes: DocsGroupModule['addRoutes'];
   export const meta: DocsGroupModule['meta'];
 }
+
+/**
+ * Shadow-DOM style isolation for live glimdown demos — see `wrapDemo()`'s
+ * own doc comment in `src/browser/virtual/wrap-demo.js` for the full
+ * rationale and usage.
+ */
+declare module 'kolay/wrap-demo' {
+  export function wrapDemo(options?: {
+    /**
+     * Custom element tag name for the shadow host.
+     *
+     * @default 'kolay-demo-shadow'
+     */
+    tagName?: string;
+
+    /**
+     * Shadow root mode.
+     *
+     * @default 'open'
+     */
+    mode?: ShadowRootMode;
+
+    /**
+     * Copy the document's `<link rel="stylesheet">` and `<style>` tags
+     * into each shadow root, so isolated demos still pick up the app's
+     * own CSS.
+     *
+     * @default true
+     */
+    includeStyles?: boolean;
+
+    /**
+     * Code-fence meta flag that opts a demo out of wrapping, e.g.
+     * ` ```gjs live no-shadow `.
+     *
+     * @default 'no-shadow'
+     */
+    skipFlag?: string;
+  }): () => (tree: unknown, file: unknown) => void;
+}

--- a/src/browser/virtual/wrap-demo.js
+++ b/src/browser/virtual/wrap-demo.js
@@ -1,0 +1,173 @@
+import { visit } from 'unist-util-visit';
+
+// Matches the placeholder repl-sdk's `gmd` compiler emits (as a raw HTML
+// node, via its internal `liveCodeExtraction` remark plugin) for each live
+// demo, e.g. `<div id="repl_3" class="repl-sdk__demo"></div>`.
+const PLACEHOLDER_PATTERN = /^<div id="([^"]+)" class="([^"]*)"><\/div>$/;
+
+/**
+ * Copies the document's stylesheets into a shadow root, so demos isolated
+ * from the surrounding page's styles still pick up the app's own CSS
+ * (mirroring `ember-primitives`' `<Shadowed includeStyles>`). Watches
+ * `document.head` for stylesheets that show up later (async chunks, HMR).
+ *
+ * @param {ShadowRoot} shadowRoot
+ * @returns {MutationObserver}
+ */
+function importStylesInto(shadowRoot) {
+  const seen = new WeakSet();
+
+  const importNode = (node) => {
+    if (seen.has(node)) return;
+
+    seen.add(node);
+    shadowRoot.appendChild(node.cloneNode(true));
+  };
+
+  const sync = () => {
+    for (const link of document.querySelectorAll('link[rel="stylesheet"]')) importNode(link);
+    for (const style of document.querySelectorAll('style')) importNode(style);
+  };
+
+  sync();
+
+  const observer = new MutationObserver(sync);
+
+  observer.observe(document.head, { childList: true });
+
+  return observer;
+}
+
+/**
+ * Defines (once per `tagName`) the custom element `wrapDemo()` renames live
+ * demo placeholders to.
+ *
+ * repl-sdk renders each demo by `appendChild`-ing it into the placeholder
+ * element some time after this element connects (see the rehype transformer
+ * below, which is what causes this element to exist in the placeholder's
+ * place to begin with) — so children can't be assumed to exist in
+ * `connectedCallback`, and are instead re-parented into the shadow root as
+ * they arrive, via `MutationObserver`.
+ *
+ * @param {string} tagName
+ * @param {ShadowRootMode} mode
+ * @param {boolean} includeStyles
+ */
+function defineElement(tagName, mode, includeStyles) {
+  if (typeof customElements === 'undefined' || customElements.get(tagName)) return;
+
+  class KolayDemoShadow extends HTMLElement {
+    #childObserver;
+    #styleObserver;
+
+    connectedCallback() {
+      if (this.shadowRoot) return;
+
+      const shadowRoot = this.attachShadow({ mode });
+
+      if (includeStyles) {
+        this.#styleObserver = importStylesInto(shadowRoot);
+      }
+
+      for (const child of [...this.childNodes]) {
+        shadowRoot.appendChild(child);
+      }
+
+      this.#childObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of mutation.addedNodes) {
+            shadowRoot.appendChild(node);
+          }
+        }
+      });
+
+      this.#childObserver.observe(this, { childList: true });
+    }
+
+    disconnectedCallback() {
+      this.#childObserver?.disconnect();
+      this.#childObserver = undefined;
+      this.#styleObserver?.disconnect();
+      this.#styleObserver = undefined;
+    }
+  }
+
+  customElements.define(tagName, KolayDemoShadow);
+}
+
+/**
+ * Style-isolates live glimdown (`.md`, runtime-compiled) demos in their own
+ * shadow root, so a demo's own styles can't leak into the surrounding docs
+ * UI and vice versa.
+ *
+ * `ember-repl` used to wrap every live demo's invocation in a `Shadowed`
+ * host; its `repl-sdk`-based rewrite grafts each compiled demo into a
+ * placeholder element as an independent step instead, with no invocation
+ * left to wrap — dropping that isolation. Rather than teach `repl-sdk`
+ * itself about shadow roots, `wrapDemo()` renames each live demo's
+ * placeholder tag to a custom element (defined as a side effect of calling
+ * `wrapDemo()`) that performs the actual `attachShadow` once the demo's
+ * rendered element is appended into it.
+ *
+ * Returns a rehype plugin — pass it to `setupKolay()` / `compilerOptions()`
+ * `rehypePlugins`:
+ *
+ * ```js
+ * import { wrapDemo } from 'kolay/wrap-demo';
+ *
+ * await setupKolay(this, {
+ *   rehypePlugins: [wrapDemo()],
+ * });
+ * ```
+ *
+ * Only wires up runtime `.md` demos compiled through `setupKolay()` /
+ * `compilerOptions()` — build-time `.gjs.md` demos go through a separate
+ * compiler and aren't affected.
+ *
+ * A fence opts out of wrapping with a meta flag (`no-shadow` by default):
+ *
+ * ```gjs live no-shadow
+ * ```
+ *
+ * @param {object} [options]
+ * @param {string} [options.tagName] Custom element tag name for the shadow host. Defaults to `'kolay-demo-shadow'`.
+ * @param {ShadowRootMode} [options.mode] Shadow root mode. Defaults to `'open'`.
+ * @param {boolean} [options.includeStyles] Copy the document's `<link rel="stylesheet">` and `<style>` tags into each shadow root. Defaults to `true`.
+ * @param {string} [options.skipFlag] Code-fence meta flag that opts a demo out of wrapping. Defaults to `'no-shadow'`.
+ */
+export function wrapDemo(options = {}) {
+  const {
+    tagName = 'kolay-demo-shadow',
+    mode = 'open',
+    includeStyles = true,
+    skipFlag = 'no-shadow',
+  } = options;
+
+  defineElement(tagName, mode, includeStyles);
+
+  return function rehypeWrapDemo() {
+    return (tree, file) => {
+      const liveCode = file?.data?.liveCode ?? [];
+
+      const wrapped = new Set(
+        liveCode
+          .filter((entry) => !entry?.meta?.includes(skipFlag))
+          .map((entry) => entry.placeholderId)
+      );
+
+      if (wrapped.size === 0) return;
+
+      visit(tree, 'raw', (node) => {
+        const match = node.value.match(PLACEHOLDER_PATTERN);
+
+        if (!match) return;
+
+        const [, id, className] = match;
+
+        if (!id || !wrapped.has(id)) return;
+
+        node.value = `<${tagName} id="${id}" class="${className}"></${tagName}>`;
+      });
+    };
+  };
+}


### PR DESCRIPTION
## Summary

`ember-repl` used to wrap every live glimdown demo's invocation in a
`Shadowed` host; its `repl-sdk`-based rewrite grafts each compiled demo
into a placeholder element as an independent step instead, with no
invocation left to wrap - dropping that isolation. #355 tried to fix
this by defaulting `ShadowComponent: true` for the `gmd` compiler, but
depended on a `repl-sdk` change ([limber#2206](https://github.com/NullVoxPopuli/limber/pull/2206))
that was closed unmerged, with the reviewer suggesting: "could this be
an opt-in rehype/remark plugin instead?"

This PR is that plugin. `wrapDemo()`, importable from `kolay/wrap-demo`
(resolved via the existing `./*` → `src/browser/virtual/*` wildcard
export, same as `kolay/empty`), is a rehype plugin factory you pass into
`setupKolay()` / `compilerOptions()`'s `rehypePlugins`:

```js
import { wrapDemo } from 'kolay/wrap-demo';

await setupKolay(this, {
  rehypePlugins: [wrapDemo()],
});
```

It renames each live demo's placeholder tag to a custom element
(defined as a side effect of calling `wrapDemo()`) that attaches an
open shadow root and re-parents the demo's rendered content into it via
`MutationObserver` once `repl-sdk` appends it (there's no component
invocation left to wrap directly), copying the document's `<link
rel="stylesheet">` / `<style>` tags in (also watched via
`MutationObserver`) so isolated demos still pick up the app's CSS -
similar to `ember-primitives`' `<Shadowed includeStyles>`, already
available in this repo's default `topLevelScope`.

A fence opts out via a `no-shadow` meta flag:

````
```gjs live no-shadow
```
````

...which this repo's own docs, `docs-typedoc`, and tests already use
throughout, apparently in anticipation of exactly this landing.

Options (all optional): `tagName` (default `'kolay-demo-shadow'`),
`mode` (default `'open'`), `includeStyles` (default `true`), `skipFlag`
(default `'no-shadow'`).

**Scope:** only wires up runtime `.md` demos compiled through
`setupKolay()` / `compilerOptions()`. Build-time `.gjs.md` demos go
through a separate compiler (`src/build/plugins/gjs-md.js`) whose own
`rehypeInjectComponentInvocation` string-matches `</div>` on the
placeholder to inject the component invocation - since it always runs
*after* consumer `rehypePlugins`, renaming the placeholder tag there
would break that injection. Teaching that pipeline about shadow roots
is a separate, harder problem left for later; happy to discuss if
there's a preferred direction.

This is carried today as a downstream, hand-rolled implementation in
[carbon-components-ember](https://github.com/carbon-design-system/carbon-components-ember/pull/722)
(`rehype-shadow-demo.ts` + `shadow-demo-element.ts`) - this PR
generalizes that into kolay itself so other consumers don't have to
reinvent it, and additionally fixes the stylesheet-importing gap that
implementation never finished (a `STYLESHEET_SELECTOR` constant it
declared but never used).

## Test plan

- [x] `pnpm lint:js` / `pnpm lint:prettier` / `pnpm lint:types` pass
- [x] `pnpm build` succeeds
- [x] new tests in `docs-app/tests/kolay/markdown/wrap-demo-test.gjs`:
      a live fence gets wrapped and renders inside its shadow root; a
      `no-shadow` fence renders in the light DOM as before
- [x] `pnpm --filter docs-app test:ember` - both new tests pass; the
      13 pre-existing `<ComponentSignature>` / `<ModifierSignature>`
      failures are unrelated to this change (no typedoc-related files
      touched) and reproduce the same way without this branch