### PR TITLE
feat: kolay() plugin generated from kolay.config.js

### DIFF
--- a/docs-app/kolay.config.js
+++ b/docs-app/kolay.config.js
@@ -25,14 +25,14 @@ export default defineConfig({
   },
 
   docs: [
-    { name: 'Runtime', src: '../docs' },
-    { name: 'TypeDoc', src: '../docs-typedoc' },
+    { name: 'Runtime', src: import.meta.resolve('../docs') },
+    { name: 'TypeDoc', src: import.meta.resolve('../docs-typedoc') },
   ],
 
   apiDocs: ['kolay', 'ember-primitives', 'ember-resources', 'ember-repl'],
 
   // live codefences import these as '#demos/site/*'
-  demos: [{ src: './demos', as: '#demos/site' }],
+  demos: [{ src: import.meta.resolve('./demos'), as: '#demos/site' }],
 
   // .md fences can import ember-primitives with no modules config
   importEntrypoints: ['ember-primitives'],

--- a/docs-app/kolay.config.js
+++ b/docs-app/kolay.config.js
@@ -1,4 +1,41 @@
+import rehypeShiki from '@shikijs/rehype';
+
 export default {
+  // Shared by every docs group below. Carries plugin functions, so it
+  // needs a JS config form (JSON forms can only hold data).
+  markdownOptions: {
+    rehypePlugins: [
+      [
+        rehypeShiki,
+        {
+          themes: {
+            light: 'github-light',
+            dark: 'github-dark',
+          },
+          defaultColor: 'light-dark()',
+        },
+      ],
+    ],
+    scope: `
+    import { APIDocs, CommentQuery, ComponentSignature, HelperSignature, ModifierSignature } from 'kolay';
+    import { Shadowed } from 'ember-primitives/components/shadowed';
+    import { InViewport } from 'ember-primitives/viewport';
+    `,
+  },
+
+  docs: [
+    { name: 'Runtime', src: '../docs' },
+    { name: 'TypeDoc', src: '../docs-typedoc' },
+  ],
+
+  apiDocs: ['kolay', 'ember-primitives', 'ember-resources', 'ember-repl'],
+
+  // live codefences import these as '#demos/site/*'
+  demos: [{ src: './demos', as: '#demos/site' }],
+
+  // .md fences can import ember-primitives with no modules config
+  importEntrypoints: ['ember-primitives'],
+
   // Old URLs from previous arrangements of this docs site.
   // The Development page about redirects uses a few of these as its examples.
   redirects: [

--- a/docs-app/kolay.config.js
+++ b/docs-app/kolay.config.js
@@ -1,6 +1,7 @@
 import rehypeShiki from '@shikijs/rehype';
+import { defineConfig } from 'kolay/vite';
 
-export default {
+export default defineConfig({
   // Shared by every docs group below. Carries plugin functions, so it
   // needs a JS config form (JSON forms can only hold data).
   markdownOptions: {
@@ -72,4 +73,4 @@ export default {
     { from: 'Runtime/util/logs', to: 'Runtime/demo-support/logs.md' },
     { from: 'Runtime/docs/owner', to: 'Runtime/demo-support/owner.md' },
   ],
-};
+});

--- a/docs-app/src/templates/development/config-file.gjs.md
+++ b/docs-app/src/templates/development/config-file.gjs.md
@@ -15,16 +15,9 @@ export default defineConfig({
 
 ```js
 // kolay.config.js
-import rehypeShiki from "@shikijs/rehype";
 import { defineConfig } from "kolay/vite";
 
 export default defineConfig({
-  // shared by every docs group; a group's own options win
-  markdownOptions: {
-    rehypePlugins: [[rehypeShiki, { themes: { light: "github-light", dark: "github-dark" } }]],
-    scope: `import { Callout } from '#ui';`,
-  },
-
   docs: [
     { name: "Runtime", src: import.meta.resolve("../docs") },
     // a plain string works too; the last segment names the group
@@ -45,33 +38,34 @@ export default defineConfig({
 
 ## Keys
 
-Every key is optional, and a key you don't specify generates nothing. Relative paths resolve from the config file's directory.
+Every key is optional. If a key isn't specified, the plugin for it is not included in your app. Relative paths resolve from the config file's directory, and `redirects` has its own page: [Redirects](/development/redirects.md).
 
-| Key                 | Shape                                                                   |
-| ------------------- | ----------------------------------------------------------------------- |
-| `docs`              | `{ name, src, ...markdown options }` entries, or path strings           |
-| `apiDocs`           | package names / paths                                                   |
-| `demos`             | `{ src, as }` entries                                                   |
-| `importEntrypoints` | package names, or `{ input, exclude }`                                  |
-| `markdownOptions`   | `scope` / `remarkPlugins` / `rehypePlugins`, shared by every docs group |
-| `redirects`         | see [Redirects](/development/redirects.md)                              |
+### `KolayConfigInput`
+
+<APIDocs @module="declarations/build/vite" @name="KolayConfigInput" @package="kolay" />
+
+### `DocsEntry`
+
+<APIDocs @module="declarations/build/vite" @name="DocsEntry" @package="kolay" />
+
+### `MarkdownOptions`
+
+<APIDocs @module="declarations/build/vite" @name="MarkdownOptions" @package="kolay" />
+
+### `DemosEntry`
+
+<APIDocs @module="declarations/build/vite" @name="DemosEntry" @package="kolay" />
+
+### `ImportEntrypointsEntry`
+
+<APIDocs @module="declarations/build/vite" @name="ImportEntrypointsEntry" @package="kolay" />
+
+## `defineConfig`
+
+<APIDocs @module="declarations/build/vite" @name="defineConfig" @package="kolay" />
 
 ## Config file forms
 
 The file is discovered with [lilconfig](https://github.com/antonk52/lilconfig): `kolay.config.js` (or `.cjs` / `.mjs`), `.kolayrc` (JSON) or `.kolayrc.json` / `.js` / `.cjs` / `.mjs`, or a `"kolay"` key in `package.json`, each also inside a `.config/` or `config/` directory. `markdownOptions` usually contains plugin functions, so it needs a JS form; JSON forms can hold everything else.
 
 The individual plugins keep working, alone or alongside `kolay()`.
-
-## API Reference
-
-<APIDocs @module="declarations/build/vite" @name="KolayConfigInput" @package="kolay" />
-
-<APIDocs @module="declarations/build/vite" @name="DocsEntry" @package="kolay" />
-
-<APIDocs @module="declarations/build/vite" @name="MarkdownOptions" @package="kolay" />
-
-<APIDocs @module="declarations/build/vite" @name="DemosEntry" @package="kolay" />
-
-<APIDocs @module="declarations/build/vite" @name="ImportEntrypointsEntry" @package="kolay" />
-
-<APIDocs @module="declarations/build/vite" @name="defineConfig" @package="kolay" />

--- a/docs-app/src/templates/development/config-file.gjs.md
+++ b/docs-app/src/templates/development/config-file.gjs.md
@@ -16,8 +16,9 @@ export default defineConfig({
 ```js
 // kolay.config.js
 import rehypeShiki from "@shikijs/rehype";
+import { defineConfig } from "kolay/vite";
 
-export default {
+export default defineConfig({
   // shared by every docs group; a group's own options win
   markdownOptions: {
     rehypePlugins: [[rehypeShiki, { themes: { light: "github-light", dark: "github-dark" } }]],
@@ -37,8 +38,10 @@ export default {
   importEntrypoints: ["ember-primitives"],
 
   redirects: [{ from: "old-section/*", to: "new-section/*" }],
-};
+});
 ```
+
+`defineConfig` is an identity function that types the config, so your editor completes and checks the keys.
 
 This site is set up this way: its [vite.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/vite.config.js) is the one-plugin form, and its [kolay.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/kolay.config.js) carries the groups, api docs, demos, import entrypoints, and redirects.
 

--- a/docs-app/src/templates/development/config-file.gjs.md
+++ b/docs-app/src/templates/development/config-file.gjs.md
@@ -1,6 +1,6 @@
 # kolay.config.js
 
-One config file can describe your whole kolay setup. The `kolay` vite plugin reads it and generates the [`docs()`](/development/configuring-docs.md), [`apiDocs()`](/development/configuring-api-docs.md), [`demos()`](/authoring/sharing-demos.md), and [`importEntrypoints()`](/development/configuring-import-entrypoints.md) plugins it describes:
+One config file describes your whole kolay setup. The `kolay` vite plugin reads it and generates the [`docs()`](/development/configuring-docs.md), [`apiDocs()`](/development/configuring-api-docs.md), [`demos()`](/authoring/sharing-demos.md), and [`importEntrypoints()`](/development/configuring-import-entrypoints.md) plugins it describes:
 
 ```js
 // vite.config.js
@@ -26,14 +26,14 @@ export default defineConfig({
   },
 
   docs: [
-    { name: "Runtime", src: "../docs" },
+    { name: "Runtime", src: import.meta.resolve("../docs") },
     // a plain string works too; the last segment names the group
     "./guides",
   ],
 
   apiDocs: ["my-library"],
 
-  demos: [{ src: "./demos", as: "#demos/site" }],
+  demos: [{ src: import.meta.resolve("./demos"), as: "#demos/site" }],
 
   importEntrypoints: ["ember-primitives"],
 
@@ -41,31 +41,37 @@ export default defineConfig({
 });
 ```
 
-`defineConfig` is an identity function that types the config, so your editor completes and checks the keys.
-
-This site is set up this way: its [vite.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/vite.config.js) is the one-plugin form, and its [kolay.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/kolay.config.js) defines the groups, api docs, demos, import entrypoints, and redirects.
+`defineConfig` types the config and validates it as the file is evaluated. This site's own [vite.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/vite.config.js) and [kolay.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/kolay.config.js) use this form.
 
 ## Keys
 
-Every key is optional, and a key you don't specify generates nothing.
+Every key is optional, and a key you don't specify generates nothing. Relative paths resolve from the config file's directory.
 
-| Key                 | Generates                           | Shape                                                  |
-| ------------------- | ----------------------------------- | ------------------------------------------------------ |
-| `docs`              | one `docs()` per entry              | `{ name, src, ...markdown options }`, or a path string |
-| `apiDocs`           | `apiDocs()`                         | package names / paths                                  |
-| `demos`             | one `demos()` per entry             | `{ src, as }`                                          |
-| `importEntrypoints` | one `importEntrypoints()` per entry | a package name, or `{ input, exclude }`                |
-| `markdownOptions`   | (merged into every `docs` entry)    | `scope`, `remarkPlugins`, `rehypePlugins`, ...         |
-| `redirects`         | (applied at runtime)                | see [Redirects](/development/redirects.md)             |
-
-Relative paths (`./demos`, `../docs`) resolve from the config file's directory.
+| Key                 | Shape                                                                   |
+| ------------------- | ----------------------------------------------------------------------- |
+| `docs`              | `{ name, src, ...markdown options }` entries, or path strings           |
+| `apiDocs`           | package names / paths                                                   |
+| `demos`             | `{ src, as }` entries                                                   |
+| `importEntrypoints` | package names, or `{ input, exclude }`                                  |
+| `markdownOptions`   | `scope` / `remarkPlugins` / `rehypePlugins`, shared by every docs group |
+| `redirects`         | see [Redirects](/development/redirects.md)                              |
 
 ## Config file forms
 
-The file is discovered with [lilconfig](https://github.com/antonk52/lilconfig): `kolay.config.js` (or `.cjs` / `.mjs`), `.kolayrc` (JSON) or `.kolayrc.json` / `.js` / `.cjs` / `.mjs`, or a `"kolay"` key in `package.json`, with every form also looked for inside a `.config/` or `config/` directory.
+The file is discovered with [lilconfig](https://github.com/antonk52/lilconfig): `kolay.config.js` (or `.cjs` / `.mjs`), `.kolayrc` (JSON) or `.kolayrc.json` / `.js` / `.cjs` / `.mjs`, or a `"kolay"` key in `package.json`, each also inside a `.config/` or `config/` directory. `markdownOptions` usually contains plugin functions, so it needs a JS form; JSON forms can hold everything else.
 
-`markdownOptions` (and a docs entry's own markdown options) usually contain plugin functions, so they need a JS config form. JSON forms can hold everything else.
+The individual plugins keep working, alone or alongside `kolay()`.
 
-## Mixing with the individual plugins
+## API Reference
 
-The individual plugins keep working, on their own or alongside `kolay()`. Usages discover each other the same way multiple direct `docs()` usages already do, so you can keep one group in the config file and add another with `docs()` directly.
+<APIDocs @module="declarations/build/vite" @name="KolayConfigInput" @package="kolay" />
+
+<APIDocs @module="declarations/build/vite" @name="DocsEntry" @package="kolay" />
+
+<APIDocs @module="declarations/build/vite" @name="MarkdownOptions" @package="kolay" />
+
+<APIDocs @module="declarations/build/vite" @name="DemosEntry" @package="kolay" />
+
+<APIDocs @module="declarations/build/vite" @name="ImportEntrypointsEntry" @package="kolay" />
+
+<APIDocs @module="declarations/build/vite" @name="defineConfig" @package="kolay" />

--- a/docs-app/src/templates/development/config-file.gjs.md
+++ b/docs-app/src/templates/development/config-file.gjs.md
@@ -43,11 +43,11 @@ export default defineConfig({
 
 `defineConfig` is an identity function that types the config, so your editor completes and checks the keys.
 
-This site is set up this way: its [vite.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/vite.config.js) is the one-plugin form, and its [kolay.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/kolay.config.js) carries the groups, api docs, demos, import entrypoints, and redirects.
+This site is set up this way: its [vite.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/vite.config.js) is the one-plugin form, and its [kolay.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/kolay.config.js) defines the groups, api docs, demos, import entrypoints, and redirects.
 
 ## Keys
 
-Every key is optional. With no `docs` entries, `kolay()` still serves the co-located pages (`app/templates` / `src/templates`) and the virtual modules `setupKolay` needs.
+Every key is optional, and a key you don't specify generates nothing.
 
 | Key                 | Generates                           | Shape                                                  |
 | ------------------- | ----------------------------------- | ------------------------------------------------------ |
@@ -56,7 +56,7 @@ Every key is optional. With no `docs` entries, `kolay()` still serves the co-loc
 | `demos`             | one `demos()` per entry             | `{ src, as }`                                          |
 | `importEntrypoints` | one `importEntrypoints()` per entry | a package name, or `{ input, exclude }`                |
 | `markdownOptions`   | (merged into every `docs` entry)    | `scope`, `remarkPlugins`, `rehypePlugins`, ...         |
-| `redirects`         | (carried on the manifest)           | see [Redirects](/development/redirects.md)             |
+| `redirects`         | (applied at runtime)                | see [Redirects](/development/redirects.md)             |
 
 Relative paths (`./demos`, `../docs`) resolve from the config file's directory.
 
@@ -64,7 +64,7 @@ Relative paths (`./demos`, `../docs`) resolve from the config file's directory.
 
 The file is discovered with [lilconfig](https://github.com/antonk52/lilconfig): `kolay.config.js` (or `.cjs` / `.mjs`), `.kolayrc` (JSON) or `.kolayrc.json` / `.js` / `.cjs` / `.mjs`, or a `"kolay"` key in `package.json`, with every form also looked for inside a `.config/` or `config/` directory.
 
-`markdownOptions` (and a docs entry's own markdown options) usually carry plugin functions, so they need a JS config form. JSON forms can hold everything else.
+`markdownOptions` (and a docs entry's own markdown options) usually contain plugin functions, so they need a JS config form. JSON forms can hold everything else.
 
 ## Mixing with the individual plugins
 

--- a/docs-app/src/templates/development/config-file.gjs.md
+++ b/docs-app/src/templates/development/config-file.gjs.md
@@ -1,0 +1,68 @@
+# kolay.config.js
+
+One config file can describe your whole kolay setup. The `kolay` vite plugin reads it and generates the [`docs()`](/development/configuring-docs.md), [`apiDocs()`](/development/configuring-api-docs.md), [`demos()`](/authoring/sharing-demos.md), and [`importEntrypoints()`](/development/configuring-import-entrypoints.md) plugins it describes:
+
+```js
+// vite.config.js
+import { ember } from "@embroider/vite";
+import { kolay } from "kolay/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [ember(), kolay()],
+});
+```
+
+```js
+// kolay.config.js
+import rehypeShiki from "@shikijs/rehype";
+
+export default {
+  // shared by every docs group; a group's own options win
+  markdownOptions: {
+    rehypePlugins: [[rehypeShiki, { themes: { light: "github-light", dark: "github-dark" } }]],
+    scope: `import { Callout } from '#ui';`,
+  },
+
+  docs: [
+    { name: "Runtime", src: "../docs" },
+    // a plain string works too; the last segment names the group
+    "./guides",
+  ],
+
+  apiDocs: ["my-library"],
+
+  demos: [{ src: "./demos", as: "#demos/site" }],
+
+  importEntrypoints: ["ember-primitives"],
+
+  redirects: [{ from: "old-section/*", to: "new-section/*" }],
+};
+```
+
+This site is set up this way: its [vite.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/vite.config.js) is the one-plugin form, and its [kolay.config.js](https://github.com/universal-ember/kolay/blob/main/docs-app/kolay.config.js) carries the groups, api docs, demos, import entrypoints, and redirects.
+
+## Keys
+
+Every key is optional. With no `docs` entries, `kolay()` still serves the co-located pages (`app/templates` / `src/templates`) and the virtual modules `setupKolay` needs.
+
+| Key                 | Generates                           | Shape                                                  |
+| ------------------- | ----------------------------------- | ------------------------------------------------------ |
+| `docs`              | one `docs()` per entry              | `{ name, src, ...markdown options }`, or a path string |
+| `apiDocs`           | `apiDocs()`                         | package names / paths                                  |
+| `demos`             | one `demos()` per entry             | `{ src, as }`                                          |
+| `importEntrypoints` | one `importEntrypoints()` per entry | a package name, or `{ input, exclude }`                |
+| `markdownOptions`   | (merged into every `docs` entry)    | `scope`, `remarkPlugins`, `rehypePlugins`, ...         |
+| `redirects`         | (carried on the manifest)           | see [Redirects](/development/redirects.md)             |
+
+Relative paths (`./demos`, `../docs`) resolve from the config file's directory.
+
+## Config file forms
+
+The file is discovered with [lilconfig](https://github.com/antonk52/lilconfig): `kolay.config.js` (or `.cjs` / `.mjs`), `.kolayrc` (JSON) or `.kolayrc.json` / `.js` / `.cjs` / `.mjs`, or a `"kolay"` key in `package.json`, with every form also looked for inside a `.config/` or `config/` directory.
+
+`markdownOptions` (and a docs entry's own markdown options) usually carry plugin functions, so they need a JS config form. JSON forms can hold everything else.
+
+## Mixing with the individual plugins
+
+The individual plugins keep working, on their own or alongside `kolay()`. Usages discover each other the same way multiple direct `docs()` usages already do, so you can keep one group in the config file and add another with `docs()` directly.

--- a/docs-app/src/templates/development/config-file.json
+++ b/docs-app/src/templates/development/config-file.json
@@ -1,0 +1,1 @@
+{ "title": "kolay.config.js" }

--- a/docs-app/src/templates/development/meta.json
+++ b/docs-app/src/templates/development/meta.json
@@ -6,6 +6,7 @@
     "renaming-pages",
     "redirects",
     "testing",
+    "config-file",
     "configuring-docs",
     "configuring-import-entrypoints",
     "configuring-api-docs",

--- a/docs-app/src/templates/development/redirects.gjs.md
+++ b/docs-app/src/templates/development/redirects.gjs.md
@@ -6,7 +6,7 @@ If your site deploys to a host with its own redirect support (Netlify, Cloudflar
 
 ## The config file
 
-Redirects are one key of [kolay.config.js](/development/config-file.md), the project-level config file (which can also describe your docs groups, api docs, demos, and import entrypoints):
+Redirects are one key of [kolay.config.js](/development/config-file.md):
 
 ```js
 // kolay.config.js
@@ -24,13 +24,13 @@ export default defineConfig({
 
 There is nothing to wire up: when [`setupKolay`](/install/index.md) runs (in your application route), the router service is subscribed automatically. Incoming transitions are rewritten before they land, and the URL the app boots on is corrected with `replaceWith`, so the back button isn't left pointing at the dead URL.
 
-The entries above are real: this site's own `kolay.config.js` carries the old URLs from its previous arrangements. Follow [/usage/setup](/usage/setup) or [/docs/component-signature](/docs/component-signature) and watch the URL bar.
+The entries above are real: this site's own `kolay.config.js` lists the old URLs from its previous arrangements. Follow [/usage/setup](/usage/setup) or [/docs/component-signature](/docs/component-signature) and watch the URL bar.
 
 ## Matching
 
 Entries are plain path prefixes, not globs, matched against the app-relative URL of every transition:
 
-- A trailing `/*` (on both `from` and `to`) matches the prefix itself and everything under it, carrying the remainder onto `to`. Without it, the entry matches only that exact path.
+- A trailing `/*` (on both `from` and `to`) matches the prefix itself and everything under it; the remainder is appended to `to`. Without it, the entry matches only that exact path.
 - Matching is whole-segment (`Runtime/*` does not match `/RuntimeExtras/...`) and case-insensitive, consistent with how kolay matches paths everywhere else. For exact entries, the `.md` extension is optional on the visited path, since pages are visitable with and without it.
 - Entries apply in order; the first match wins.
 - Paths are app-relative (a leading `/` is allowed and ignored). The deploy's `rootURL` is handled for you.

--- a/docs-app/src/templates/development/redirects.gjs.md
+++ b/docs-app/src/templates/development/redirects.gjs.md
@@ -6,7 +6,7 @@ If your site deploys to a host with its own redirect support (Netlify, Cloudflar
 
 ## The config file
 
-Redirects live in a project-level config file, discovered at build time with [lilconfig](https://github.com/antonk52/lilconfig): `kolay.config.js` (or `.cjs` / `.mjs`), `.kolayrc` (JSON) or `.kolayrc.json` / `.js` / `.cjs` / `.mjs`, or a `"kolay"` key in `package.json`. Every rc and config-file form is also looked for inside a `.config/` or `config/` directory.
+Redirects are one key of [kolay.config.js](/development/config-file.md), the project-level config file (which can also describe your docs groups, api docs, demos, and import entrypoints):
 
 ```js
 // kolay.config.js

--- a/docs-app/src/templates/development/redirects.gjs.md
+++ b/docs-app/src/templates/development/redirects.gjs.md
@@ -10,14 +10,16 @@ Redirects are one key of [kolay.config.js](/development/config-file.md), the pro
 
 ```js
 // kolay.config.js
-export default {
+import { defineConfig } from "kolay/vite";
+
+export default defineConfig({
   redirects: [
     // a moved subtree
     { from: "docs/*", to: "TypeDoc/components/*" },
     // a single moved page
     { from: "usage/setup", to: "install/index.md" },
   ],
-};
+});
 ```
 
 There is nothing to wire up: when [`setupKolay`](/install/index.md) runs (in your application route), the router service is subscribed automatically. Incoming transitions are rewritten before they land, and the URL the app boots on is corrected with `replaceWith`, so the back button isn't left pointing at the dead URL.

--- a/docs-app/vite.config.js
+++ b/docs-app/vite.config.js
@@ -1,31 +1,10 @@
 import { ember, extensions } from '@embroider/vite';
 
 import { babel } from '@rollup/plugin-babel';
-import rehypeShiki from '@shikijs/rehype';
-import { apiDocs, demos, docs, importEntrypoints } from 'kolay/vite';
+import { kolay } from 'kolay/vite';
 import info from 'unplugin-info/vite';
 import { defineConfig } from 'vite';
 import inspect from 'vite-plugin-inspect';
-
-const sharedMarkdownOptions = {
-  rehypePlugins: [
-    [
-      rehypeShiki,
-      {
-        themes: {
-          light: 'github-light',
-          dark: 'github-dark',
-        },
-        defaultColor: 'light-dark()',
-      },
-    ],
-  ],
-  scope: `
-  import { APIDocs, CommentQuery, ComponentSignature, HelperSignature, ModifierSignature } from 'kolay';
-  import { Shadowed } from 'ember-primitives/components/shadowed';
-  import { InViewport } from 'ember-primitives/viewport';
-  `,
-};
 
 export default defineConfig(async ({ mode }) => {
   const isDev = mode === 'development';
@@ -35,19 +14,9 @@ export default defineConfig(async ({ mode }) => {
       inspect(),
       info(),
       ember(),
-      docs('Runtime', {
-        src: import.meta.resolve('../docs', import.meta.url),
-        ...sharedMarkdownOptions,
-      }),
-      docs('TypeDoc', {
-        src: import.meta.resolve('../docs-typedoc', import.meta.url),
-        ...sharedMarkdownOptions,
-      }),
-      apiDocs(['kolay', 'ember-primitives', 'ember-resources', 'ember-repl']),
-      // live codefences import these as '#demos/site/*'
-      demos(import.meta.resolve('./demos', import.meta.url), { as: '#demos/site' }),
-      // .md fences can import ember-primitives with no modules config
-      importEntrypoints('ember-primitives'),
+      // docs, apiDocs, demos, and importEntrypoints, generated from
+      // this app's kolay.config.js
+      kolay(),
       babel({
         babelHelpers: 'runtime',
         extensions,

--- a/docs-app/vite.config.js
+++ b/docs-app/vite.config.js
@@ -14,8 +14,6 @@ export default defineConfig(async ({ mode }) => {
       inspect(),
       info(),
       ember(),
-      // docs, apiDocs, demos, and importEntrypoints, generated from
-      // this app's kolay.config.js
       kolay(),
       babel({
         babelHelpers: 'runtime',

--- a/src/build/plugins/fixtures/kolay-config/js-config/kolay.config.js
+++ b/src/build/plugins/fixtures/kolay-config/js-config/kolay.config.js
@@ -1,6 +1,8 @@
-export default {
+import { defineConfig } from 'kolay/vite';
+
+export default defineConfig({
   redirects: [
     { from: 'Old/*', to: 'New/*' },
     { from: 'legacy/page', to: 'modern/page' },
   ],
-};
+});

--- a/src/build/plugins/from-config.js
+++ b/src/build/plugins/from-config.js
@@ -32,10 +32,10 @@ function resolveFrom(configDir, src) {
 }
 
 /**
- * The plugins a kolay config describes: one `docs()` per `docs` entry
- * (or a single group-less one, so the co-located pages and the virtual
- * modules are always served), plus `apiDocs()`, `demos()`, and
- * `importEntrypoints()` when configured.
+ * The plugins a kolay config describes: one `docs()` per `docs` entry,
+ * one `demos()` / `importEntrypoints()` per entry of theirs, and one
+ * `apiDocs()` for the `apiDocs` list. A key that is not specified
+ * generates nothing.
  *
  * `markdownOptions` is shared by every docs entry; an entry's own
  * options win.
@@ -47,46 +47,48 @@ export function pluginsFromConfig(config, configDir) {
   const markdownOptions = config.markdownOptions ?? {};
   const plugins = [];
 
-  const docsEntries = toArray(config.docs);
-
-  if (docsEntries.length === 0) {
-    plugins.push(docs.vite([undefined, { ...markdownOptions }]));
-  }
-
-  for (const entry of docsEntries) {
+  for (const entry of toArray(config.docs)) {
     if (typeof entry === 'string') {
-      plugins.push(docs.vite([resolveFrom(configDir, entry), { ...markdownOptions }]));
+      const src = resolveFrom(configDir, entry);
+
+      plugins.push(docs.vite([src, { ...markdownOptions }]));
       continue;
     }
 
-    const { name, src, ...overrides } = entry ?? {};
+    const { name, src, ...entryOptions } = entry ?? {};
+    const resolvedSrc = resolveFrom(configDir, src);
+    const options = { src: resolvedSrc, ...markdownOptions, ...entryOptions };
 
-    plugins.push(
-      docs.vite([name, { src: resolveFrom(configDir, src), ...markdownOptions, ...overrides }])
-    );
+    plugins.push(docs.vite([name, options]));
   }
 
-  const apiDocsPackages = toArray(config.apiDocs);
+  const apiDocsInput = toArray(config.apiDocs);
 
-  if (apiDocsPackages.length > 0) {
-    plugins.push(apiDocs.vite(apiDocsPackages.map((pkg) => resolveFrom(configDir, pkg))));
+  if (apiDocsInput.length > 0) {
+    const packages = apiDocsInput.map((pkg) => resolveFrom(configDir, pkg));
+
+    plugins.push(apiDocs.vite(packages));
   }
 
   for (const entry of toArray(config.demos)) {
     const { src, ...options } = entry ?? {};
+    const resolvedSrc = resolveFrom(configDir, src);
 
-    plugins.push(demos.vite([resolveFrom(configDir, src), options]));
+    plugins.push(demos.vite([resolvedSrc, options]));
   }
 
   for (const entry of toArray(config.importEntrypoints)) {
     if (typeof entry === 'string') {
-      plugins.push(importEntrypoints.vite([resolveFrom(configDir, entry), undefined]));
+      const input = resolveFrom(configDir, entry);
+
+      plugins.push(importEntrypoints.vite([input, undefined]));
       continue;
     }
 
     const { input, ...options } = entry ?? {};
+    const resolvedInput = resolveFrom(configDir, input);
 
-    plugins.push(importEntrypoints.vite([resolveFrom(configDir, input), options]));
+    plugins.push(importEntrypoints.vite([resolvedInput, options]));
   }
 
   return plugins;

--- a/src/build/plugins/from-config.js
+++ b/src/build/plugins/from-config.js
@@ -1,0 +1,118 @@
+import { dirname, resolve } from 'node:path';
+
+import { apiDocs, demos, docs, importEntrypoints } from './index.js';
+import { loadKolayConfig } from './kolay-config.js';
+
+/**
+ * @typedef {import('./kolay-config.js').KolayConfig} KolayConfig
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {any[]}
+ */
+function toArray(value) {
+  if (value === undefined) return [];
+
+  return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Relative paths in the config file resolve from the file's own
+ * directory; everything else (absolute paths, file URLs, package
+ * names) passes through.
+ *
+ * @param {string} configDir
+ * @param {unknown} src
+ */
+function resolveFrom(configDir, src) {
+  if (typeof src !== 'string') return src;
+
+  return src.startsWith('./') || src.startsWith('../') ? resolve(configDir, src) : src;
+}
+
+/**
+ * The plugins a kolay config describes: one `docs()` per `docs` entry
+ * (or a single group-less one, so the co-located pages and the virtual
+ * modules are always served), plus `apiDocs()`, `demos()`, and
+ * `importEntrypoints()` when configured.
+ *
+ * `markdownOptions` is shared by every docs entry; an entry's own
+ * options win.
+ *
+ * @param {KolayConfig} config
+ * @param {string} configDir
+ */
+export function pluginsFromConfig(config, configDir) {
+  const markdownOptions = config.markdownOptions ?? {};
+  const plugins = [];
+
+  const docsEntries = toArray(config.docs);
+
+  if (docsEntries.length === 0) {
+    plugins.push(docs.vite([undefined, { ...markdownOptions }]));
+  }
+
+  for (const entry of docsEntries) {
+    if (typeof entry === 'string') {
+      plugins.push(docs.vite([resolveFrom(configDir, entry), { ...markdownOptions }]));
+      continue;
+    }
+
+    const { name, src, ...overrides } = entry ?? {};
+
+    plugins.push(
+      docs.vite([name, { src: resolveFrom(configDir, src), ...markdownOptions, ...overrides }])
+    );
+  }
+
+  const apiDocsPackages = toArray(config.apiDocs);
+
+  if (apiDocsPackages.length > 0) {
+    plugins.push(apiDocs.vite(apiDocsPackages.map((pkg) => resolveFrom(configDir, pkg))));
+  }
+
+  for (const entry of toArray(config.demos)) {
+    const { src, ...options } = entry ?? {};
+
+    plugins.push(demos.vite([resolveFrom(configDir, src), options]));
+  }
+
+  for (const entry of toArray(config.importEntrypoints)) {
+    if (typeof entry === 'string') {
+      plugins.push(importEntrypoints.vite([resolveFrom(configDir, entry), undefined]));
+      continue;
+    }
+
+    const { input, ...options } = entry ?? {};
+
+    plugins.push(importEntrypoints.vite([resolveFrom(configDir, input), options]));
+  }
+
+  return plugins;
+}
+
+/**
+ * The all-in-one plugin: discovers the project's kolay config file and
+ * generates the `docs()`, `apiDocs()`, `demos()`, and
+ * `importEntrypoints()` plugins it describes.
+ *
+ * ```js
+ * // vite.config.js
+ * import { kolay } from 'kolay/vite';
+ *
+ * export default defineConfig({
+ *   plugins: [ember(), kolay()],
+ * });
+ * ```
+ *
+ * The individual plugins remain available and compose with this one —
+ * their usages and the generated ones discover each other the same way
+ * multiple direct usages do.
+ */
+export async function kolay() {
+  const cwd = process.cwd();
+  const { config, filepath } = await loadKolayConfig(cwd);
+
+  return pluginsFromConfig(config, filepath ? dirname(filepath) : cwd);
+}

--- a/src/build/plugins/from-config.test.ts
+++ b/src/build/plugins/from-config.test.ts
@@ -27,11 +27,8 @@ function docsState(plugins: unknown[]) {
 }
 
 describe('pluginsFromConfig', () => {
-  it('an empty config still yields one docs usage (co-located pages, virtual modules)', () => {
-    const plugins = pluginsFromConfig({ redirects: [] }, configDir);
-
-    expect(names(plugins)).toContain('kolay:setup');
-    expect(docsState(plugins)).toHaveLength(1);
+  it('a key that is not specified generates nothing', () => {
+    expect(pluginsFromConfig({ redirects: [] }, configDir)).toEqual([]);
   });
 
   it('generates one docs usage per entry, resolving src from the config dir', () => {

--- a/src/build/plugins/from-config.test.ts
+++ b/src/build/plugins/from-config.test.ts
@@ -1,0 +1,99 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { pluginsFromConfig } from './from-config.js';
+
+const configDir = '/some/project';
+// demos() checks its path exists at construction, so use a real one
+const here = dirname(fileURLToPath(import.meta.url));
+
+interface PluginLike {
+  name: string;
+  api?: { kolay?: { options: Record<string, unknown> } };
+}
+
+function flatten(plugins: unknown[]): PluginLike[] {
+  return plugins.flat(Infinity) as PluginLike[];
+}
+
+function names(plugins: unknown[]): string[] {
+  return [...new Set(flatten(plugins).map((plugin) => plugin.name))];
+}
+
+function docsState(plugins: unknown[]) {
+  return flatten(plugins).flatMap((plugin) => plugin.api?.kolay ?? []);
+}
+
+describe('pluginsFromConfig', () => {
+  it('an empty config still yields one docs usage (co-located pages, virtual modules)', () => {
+    const plugins = pluginsFromConfig({ redirects: [] }, configDir);
+
+    expect(names(plugins)).toContain('kolay:setup');
+    expect(docsState(plugins)).toHaveLength(1);
+  });
+
+  it('generates one docs usage per entry, resolving src from the config dir', () => {
+    const plugins = pluginsFromConfig(
+      {
+        redirects: [],
+        docs: [{ name: 'Runtime', src: '../docs' }, './guides'],
+      },
+      configDir
+    );
+
+    const [runtime, guides] = docsState(plugins).map(
+      (state) => state.options as { groups: { name: string; src: string }[] }
+    );
+
+    expect(runtime?.groups).toEqual([{ name: 'Runtime', src: join('/some', 'docs') }]);
+    expect(guides?.groups).toEqual([{ name: 'guides', src: join(configDir, 'guides') }]);
+  });
+
+  it('shares markdownOptions with every docs entry; the entry wins on conflict', () => {
+    const remark = () => {};
+    const override = () => {};
+
+    const plugins = pluginsFromConfig(
+      {
+        redirects: [],
+        markdownOptions: { scope: `import { X } from 'x';`, remarkPlugins: [remark] },
+        docs: [
+          { name: 'A', src: '/abs/a' },
+          { name: 'B', src: '/abs/b', remarkPlugins: [override] },
+        ],
+      },
+      configDir
+    );
+
+    const [a, b] = docsState(plugins).map((state) => state.options);
+
+    expect(a?.scope).toBe(`import { X } from 'x';`);
+    expect(a?.remarkPlugins).toEqual([remark]);
+    expect(b?.scope).toBe(`import { X } from 'x';`);
+    expect(b?.remarkPlugins).toEqual([override]);
+  });
+
+  it('generates apiDocs, demos, and importEntrypoints only when configured', () => {
+    const bare = pluginsFromConfig({ redirects: [] }, configDir);
+
+    expect(names(bare)).not.toContain('kolay:apidocs');
+    expect(names(bare)).not.toContain('kolay:demos');
+    expect(names(bare)).not.toContain('kolay:import-entrypoints');
+
+    const full = pluginsFromConfig(
+      {
+        redirects: [],
+        apiDocs: ['kolay'],
+        demos: [{ src: join(here, 'fixtures'), as: '#demos/site' }],
+        importEntrypoints: ['ember-primitives'],
+      },
+      configDir
+    );
+
+    expect(names(full)).toContain('kolay:apidocs');
+    expect(names(full)).toContain('kolay:demos');
+    expect(names(full)).toContain('kolay:import-entrypoints');
+  });
+});

--- a/src/build/plugins/kolay-config.js
+++ b/src/build/plugins/kolay-config.js
@@ -3,11 +3,15 @@ import { lilconfig } from 'lilconfig';
 /**
  * @typedef {{ from: string, to: string }} Redirect
  *
+ * The markdown options shared by every docs group (a group's own
+ * options win). Plugin functions require a JS config form.
+ * @typedef {Omit<import('./docs-args.js').DocsOptions, 'src'>} MarkdownOptions
+ *
  * One `docs()` usage: a group name and where its pages live (relative
  * paths resolve from the config file's directory), plus any per-group
  * markdown options. A plain string is shorthand for a path whose last
  * segment names the group.
- * @typedef {{ name?: string, src?: string } & Record<string, unknown>} DocsEntry
+ * @typedef {{ name?: string } & import('./docs-args.js').DocsOptions} DocsEntry
  *
  * @typedef {object} DemosEntry - one `demos()` usage
  * @property {string} src - where the demo components live; relative paths resolve from the config file's directory
@@ -17,14 +21,37 @@ import { lilconfig } from 'lilconfig';
  * @property {string} input - a package name, or a path to a directory containing a package.json
  * @property {string[]} [exclude] - subpath keys to leave out
  *
- * @typedef {object} KolayConfig
- * @property {Redirect[]} redirects
+ * What a kolay.config.js may export.
+ * @typedef {object} KolayConfigInput
+ * @property {Redirect[]} [redirects]
  * @property {Array<string | DocsEntry> | string | DocsEntry} [docs]
  * @property {string[] | string} [apiDocs]
  * @property {DemosEntry[] | DemosEntry} [demos]
  * @property {Array<string | ImportEntrypointsEntry> | string | ImportEntrypointsEntry} [importEntrypoints]
- * @property {object} [markdownOptions] - shared by every docs entry (scope, remarkPlugins, rehypePlugins, ...); plugin functions require a JS config form
+ * @property {MarkdownOptions} [markdownOptions]
+ *
+ * The loaded config: the known keys validated and defaulted.
+ * @typedef {KolayConfigInput & { redirects: Redirect[] }} KolayConfig
  */
+
+/**
+ * Identity helper for authoring kolay.config.js with editor types:
+ *
+ * ```js
+ * // kolay.config.js
+ * import { defineConfig } from 'kolay/vite';
+ *
+ * export default defineConfig({
+ *   docs: [{ name: 'Runtime', src: '../docs' }],
+ * });
+ * ```
+ *
+ * @param {KolayConfigInput} config
+ * @returns {KolayConfigInput}
+ */
+export function defineConfig(config) {
+  return config;
+}
 
 const SUBTREE = '/*';
 

--- a/src/build/plugins/kolay-config.js
+++ b/src/build/plugins/kolay-config.js
@@ -2,7 +2,28 @@ import { lilconfig } from 'lilconfig';
 
 /**
  * @typedef {{ from: string, to: string }} Redirect
- * @typedef {{ redirects: Redirect[] }} KolayConfig
+ *
+ * One `docs()` usage: a group name and where its pages live (relative
+ * paths resolve from the config file's directory), plus any per-group
+ * markdown options. A plain string is shorthand for a path whose last
+ * segment names the group.
+ * @typedef {{ name?: string, src?: string } & Record<string, unknown>} DocsEntry
+ *
+ * @typedef {object} DemosEntry - one `demos()` usage
+ * @property {string} src - where the demo components live; relative paths resolve from the config file's directory
+ * @property {string} as - the import alias, e.g. '#demos/site'
+ *
+ * @typedef {object} ImportEntrypointsEntry - one `importEntrypoints()` usage; a plain string is shorthand for `{ input }`
+ * @property {string} input - a package name, or a path to a directory containing a package.json
+ * @property {string[]} [exclude] - subpath keys to leave out
+ *
+ * @typedef {object} KolayConfig
+ * @property {Redirect[]} redirects
+ * @property {Array<string | DocsEntry> | string | DocsEntry} [docs]
+ * @property {string[] | string} [apiDocs]
+ * @property {DemosEntry[] | DemosEntry} [demos]
+ * @property {Array<string | ImportEntrypointsEntry> | string | ImportEntrypointsEntry} [importEntrypoints]
+ * @property {object} [markdownOptions] - shared by every docs entry (scope, remarkPlugins, rehypePlugins, ...); plugin functions require a JS config form
  */
 
 const SUBTREE = '/*';
@@ -194,11 +215,12 @@ export function validateRedirects(value, source) {
 /**
  * Discovers and loads the project's kolay config file (see
  * `searchPlaces`), searching upward from `cwd`. The whole config is
- * returned — `redirects` is just the first thing it carries — with the
- * known keys validated and defaulted.
+ * returned, with the known keys validated and defaulted, along with the
+ * discovered file's path (undefined when there is no config file) —
+ * relative paths inside the config resolve from the file's directory.
  *
  * @param {string} cwd
- * @returns {Promise<KolayConfig>}
+ * @returns {Promise<{ config: KolayConfig, filepath: string | undefined }>}
  */
 export async function loadKolayConfig(cwd) {
   const result = await lilconfig('kolay', { searchPlaces }).search(cwd);
@@ -206,7 +228,10 @@ export async function loadKolayConfig(cwd) {
   const config = (result && !result.isEmpty && result.config) || {};
 
   return {
-    ...config,
-    redirects: validateRedirects(config.redirects, result?.filepath ?? 'the kolay config'),
+    config: {
+      ...config,
+      redirects: validateRedirects(config.redirects, result?.filepath ?? 'the kolay config'),
+    },
+    filepath: result?.filepath ?? undefined,
   };
 }

--- a/src/build/plugins/kolay-config.js
+++ b/src/build/plugins/kolay-config.js
@@ -35,7 +35,9 @@ import { lilconfig } from 'lilconfig';
  */
 
 /**
- * Identity helper for authoring kolay.config.js with editor types:
+ * Helper for authoring kolay.config.js: types the config for editor
+ * completion and checking, and validates the known keys while the
+ * config file is evaluated, so errors point at the file itself.
  *
  * ```js
  * // kolay.config.js
@@ -50,6 +52,10 @@ import { lilconfig } from 'lilconfig';
  * @returns {KolayConfigInput}
  */
 export function defineConfig(config) {
+  if (config.redirects !== undefined) {
+    return { ...config, redirects: validateRedirects(config.redirects, 'defineConfig()') };
+  }
+
   return config;
 }
 

--- a/src/build/plugins/kolay-config.js
+++ b/src/build/plugins/kolay-config.js
@@ -1,63 +1,13 @@
 import { lilconfig } from 'lilconfig';
 
 /**
- * @typedef {{ from: string, to: string }} Redirect
+ * The config-shape types live in '../vite.js', beside `kolay()` and
+ * `defineConfig`.
  *
- * The markdown options shared by every docs group (a group's own
- * options win). Plugin functions require a JS config form.
- * @typedef {Omit<import('./docs-args.js').DocsOptions, 'src'>} MarkdownOptions
- *
- * One `docs()` usage: a group name and where its pages live (relative
- * paths resolve from the config file's directory), plus any per-group
- * markdown options. A plain string is shorthand for a path whose last
- * segment names the group.
- * @typedef {{ name?: string } & import('./docs-args.js').DocsOptions} DocsEntry
- *
- * @typedef {object} DemosEntry - one `demos()` usage
- * @property {string} src - where the demo components live; relative paths resolve from the config file's directory
- * @property {string} as - the import alias, e.g. '#demos/site'
- *
- * @typedef {object} ImportEntrypointsEntry - one `importEntrypoints()` usage; a plain string is shorthand for `{ input }`
- * @property {string} input - a package name, or a path to a directory containing a package.json
- * @property {string[]} [exclude] - subpath keys to leave out
- *
- * What a kolay.config.js may export.
- * @typedef {object} KolayConfigInput
- * @property {Redirect[]} [redirects]
- * @property {Array<string | DocsEntry> | string | DocsEntry} [docs]
- * @property {string[] | string} [apiDocs]
- * @property {DemosEntry[] | DemosEntry} [demos]
- * @property {Array<string | ImportEntrypointsEntry> | string | ImportEntrypointsEntry} [importEntrypoints]
- * @property {MarkdownOptions} [markdownOptions]
- *
- * The loaded config: the known keys validated and defaulted.
+ * @typedef {import('../vite.js').Redirect} Redirect
+ * @typedef {import('../vite.js').KolayConfigInput} KolayConfigInput
  * @typedef {KolayConfigInput & { redirects: Redirect[] }} KolayConfig
  */
-
-/**
- * Helper for authoring kolay.config.js: types the config for editor
- * completion and checking, and validates the known keys while the
- * config file is evaluated, so errors point at the file itself.
- *
- * ```js
- * // kolay.config.js
- * import { defineConfig } from 'kolay/vite';
- *
- * export default defineConfig({
- *   docs: [{ name: 'Runtime', src: '../docs' }],
- * });
- * ```
- *
- * @param {KolayConfigInput} config
- * @returns {KolayConfigInput}
- */
-export function defineConfig(config) {
-  if (config.redirects !== undefined) {
-    return { ...config, redirects: validateRedirects(config.redirects, 'defineConfig()') };
-  }
-
-  return config;
-}
 
 const SUBTREE = '/*';
 

--- a/src/build/plugins/kolay-config.test.ts
+++ b/src/build/plugins/kolay-config.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { loadKolayConfig, validateRedirects } from './kolay-config.js';
+import { defineConfig, loadKolayConfig, validateRedirects } from './kolay-config.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtures = join(here, 'fixtures', 'kolay-config');
@@ -35,6 +35,20 @@ describe('loadKolayConfig', () => {
       config: { redirects: [] },
       filepath: undefined,
     });
+  });
+});
+
+describe('defineConfig', () => {
+  it('validates redirects while the config file is evaluated', () => {
+    expect(() => defineConfig({ redirects: [{ from: 'a/*', to: 'b' }] })).toThrow(/must agree/);
+
+    expect(defineConfig({ redirects: [{ from: '/a/*', to: '/b/*' }] })).toEqual({
+      redirects: [{ from: 'a/*', to: 'b/*' }],
+    });
+  });
+
+  it('does not add keys the config did not specify', () => {
+    expect(defineConfig({})).toEqual({});
   });
 });
 

--- a/src/build/plugins/kolay-config.test.ts
+++ b/src/build/plugins/kolay-config.test.ts
@@ -3,7 +3,8 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { defineConfig, loadKolayConfig, validateRedirects } from './kolay-config.js';
+import { defineConfig } from '../vite.js';
+import { loadKolayConfig, validateRedirects } from './kolay-config.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtures = join(here, 'fixtures', 'kolay-config');

--- a/src/build/plugins/kolay-config.test.ts
+++ b/src/build/plugins/kolay-config.test.ts
@@ -11,23 +11,30 @@ const fixtures = join(here, 'fixtures', 'kolay-config');
 describe('loadKolayConfig', () => {
   // lilconfig owns the file forms / extensions — one fixture proves the
   // wiring, one proves our added config/ search directory
-  it('loads a discovered config file', async () => {
+  it('loads a discovered config file, reporting its path', async () => {
     expect(await loadKolayConfig(join(fixtures, 'js-config'))).toEqual({
-      redirects: [
-        { from: 'Old/*', to: 'New/*' },
-        { from: 'legacy/page', to: 'modern/page' },
-      ],
+      config: {
+        redirects: [
+          { from: 'Old/*', to: 'New/*' },
+          { from: 'legacy/page', to: 'modern/page' },
+        ],
+      },
+      filepath: join(fixtures, 'js-config', 'kolay.config.js'),
     });
   });
 
   it('also searches a config/ directory', async () => {
     expect(await loadKolayConfig(join(fixtures, 'config-dir'))).toEqual({
-      redirects: [{ from: 'in-config-dir/*', to: 'found/*' }],
+      config: { redirects: [{ from: 'in-config-dir/*', to: 'found/*' }] },
+      filepath: join(fixtures, 'config-dir', 'config', 'kolayrc.json'),
     });
   });
 
   it('defaults every known key when no config file exists', async () => {
-    expect(await loadKolayConfig(join(fixtures, 'none'))).toEqual({ redirects: [] });
+    expect(await loadKolayConfig(join(fixtures, 'none'))).toEqual({
+      config: { redirects: [] },
+      filepath: undefined,
+    });
   });
 });
 

--- a/src/build/plugins/setup.js
+++ b/src/build/plugins/setup.js
@@ -334,7 +334,7 @@ export const setup = (state) => {
         // primary usage only. Validation errors fail the build / dev
         // server start.
         if (state.isPrimary) {
-          kolayConfig = await loadKolayConfig(cwd);
+          kolayConfig = (await loadKolayConfig(cwd)).config;
         }
 
         resolvedConfig.server ||= {};

--- a/src/build/vite.js
+++ b/src/build/vite.js
@@ -4,9 +4,94 @@ import {
   docs as _docs,
   importEntrypoints as _importEntrypoints,
 } from './plugins/index.js';
+import { validateRedirects } from './plugins/kolay-config.js';
 
 export { kolay } from './plugins/from-config.js';
-export { defineConfig } from './plugins/kolay-config.js';
+
+/**
+ * One redirect: an old path and where it now lives. A trailing `/*`
+ * (on both `from` and `to`) matches the whole subtree.
+ *
+ * @typedef {object} Redirect
+ * @property {string} from - the old path
+ * @property {string} to - the destination
+ */
+
+/**
+ * Markdown options shared by every docs group (a group's own options
+ * win). Plugin functions require a JS config form.
+ *
+ * @typedef {object} MarkdownOptions
+ * @property {unknown[]} [remarkPlugins] - remark plugins for the groups' `.gjs.md` files
+ * @property {unknown[]} [rehypePlugins] - rehype plugins for the groups' `.gjs.md` files
+ * @property {string} [scope] - import statements made available in the groups' live codefences
+ */
+
+/**
+ * One `docs()` usage. A plain string entry is shorthand for a path
+ * whose last segment names the group.
+ *
+ * @typedef {object} DocsEntry
+ * @property {string} [name] - the group name
+ * @property {string} [src] - where the group's pages live; relative paths resolve from the config file's directory
+ * @property {unknown[]} [remarkPlugins] - remark plugins for this group's `.gjs.md` files
+ * @property {unknown[]} [rehypePlugins] - rehype plugins for this group's `.gjs.md` files
+ * @property {string} [scope] - import statements made available in this group's live codefences
+ */
+
+/**
+ * One `demos()` usage.
+ *
+ * @typedef {object} DemosEntry
+ * @property {string} src - where the demo components live; relative paths resolve from the config file's directory
+ * @property {string} as - the import alias, e.g. '#demos/site'
+ */
+
+/**
+ * One `importEntrypoints()` usage. A plain string entry is shorthand
+ * for `{ input }`.
+ *
+ * @typedef {object} ImportEntrypointsEntry
+ * @property {string} input - a package name, or a path to a directory containing a package.json
+ * @property {string[]} [exclude] - subpath keys to leave out
+ */
+
+/**
+ * What a kolay.config.js may export.
+ *
+ * @typedef {object} KolayConfigInput
+ * @property {Array<string | DocsEntry> | string | DocsEntry} [docs]
+ * @property {string[] | string} [apiDocs] - package names / paths to generate typedoc for
+ * @property {DemosEntry[] | DemosEntry} [demos]
+ * @property {Array<string | ImportEntrypointsEntry> | string | ImportEntrypointsEntry} [importEntrypoints]
+ * @property {MarkdownOptions} [markdownOptions]
+ * @property {Redirect[]} [redirects]
+ */
+
+/**
+ * Helper for authoring kolay.config.js: types the config for editor
+ * completion and checking, and validates the known keys while the
+ * config file is evaluated, so errors point at the file itself.
+ *
+ * ```js
+ * // kolay.config.js
+ * import { defineConfig } from 'kolay/vite';
+ *
+ * export default defineConfig({
+ *   docs: [{ name: 'Runtime', src: import.meta.resolve('../docs') }],
+ * });
+ * ```
+ *
+ * @param {KolayConfigInput} config
+ * @returns {KolayConfigInput}
+ */
+export function defineConfig(config) {
+  if (config.redirects !== undefined) {
+    return { ...config, redirects: validateRedirects(config.redirects, 'defineConfig()') };
+  }
+
+  return config;
+}
 
 /**
  * The markdown-docs plugin. One usage per group:

--- a/src/build/vite.js
+++ b/src/build/vite.js
@@ -5,6 +5,8 @@ import {
   importEntrypoints as _importEntrypoints,
 } from './plugins/index.js';
 
+export { kolay } from './plugins/from-config.js';
+
 /**
  * The markdown-docs plugin. One usage per group:
  *

--- a/src/build/vite.js
+++ b/src/build/vite.js
@@ -57,15 +57,16 @@ export { kolay } from './plugins/from-config.js';
  */
 
 /**
- * What a kolay.config.js may export.
+ * What a kolay.config.js may export. Every key is optional; when a key
+ * isn't specified, the plugin for it is not included in your app.
  *
  * @typedef {object} KolayConfigInput
- * @property {Array<string | DocsEntry> | string | DocsEntry} [docs]
+ * @property {Array<string | DocsEntry> | string | DocsEntry} [docs] - the docs groups; one `docs()` usage per entry
  * @property {string[] | string} [apiDocs] - package names / paths to generate typedoc for
- * @property {DemosEntry[] | DemosEntry} [demos]
- * @property {Array<string | ImportEntrypointsEntry> | string | ImportEntrypointsEntry} [importEntrypoints]
- * @property {MarkdownOptions} [markdownOptions]
- * @property {Redirect[]} [redirects]
+ * @property {DemosEntry[] | DemosEntry} [demos] - demo directories; one `demos()` usage per entry
+ * @property {Array<string | ImportEntrypointsEntry> | string | ImportEntrypointsEntry} [importEntrypoints] - packages live codefences may import; one `importEntrypoints()` usage per entry
+ * @property {MarkdownOptions} [markdownOptions] - markdown options shared by every docs group
+ * @property {Redirect[]} [redirects] - old paths and where they now live
  */
 
 /**

--- a/src/build/vite.js
+++ b/src/build/vite.js
@@ -6,6 +6,7 @@ import {
 } from './plugins/index.js';
 
 export { kolay } from './plugins/from-config.js';
+export { defineConfig } from './plugins/kolay-config.js';
 
 /**
  * The markdown-docs plugin. One usage per group:


### PR DESCRIPTION
Extends the config file (from #363): a single `kolay()` plugin (new export from `kolay/vite`) discovers `kolay.config.js` and generates the `docs()`, `apiDocs()`, `demos()`, and `importEntrypoints()` plugins it describes. Nothing existing is dropped; the individual plugins are unchanged and compose with `kolay()` through the same usage-discovery that multiple direct `docs()` usages already use.

```js
// vite.config.js
import { kolay } from "kolay/vite";

export default defineConfig({ plugins: [ember(), kolay()] });
```

```js
// kolay.config.js
import rehypeShiki from "@shikijs/rehype";
import { defineConfig } from "kolay/vite";

export default defineConfig({
  markdownOptions: { rehypePlugins: [[rehypeShiki, { ... }]], scope: `...` },
  docs: [{ name: "Runtime", src: "../docs" }, "./guides"],
  apiDocs: ["my-library"],
  demos: [{ src: "./demos", as: "#demos/site" }],
  importEntrypoints: ["ember-primitives"],
  redirects: [ ... ],
});
```

Details:

- `defineConfig` (also exported from `kolay/vite`) types the config for editor completion and checking, and validates the known keys while the config file is evaluated, so errors point at the file itself.
- `markdownOptions` is shared by every docs group; a group's own options win. Since it usually carries plugin functions, it needs a JS config form (`.js`/`.cjs`/`.mjs`); JSON forms can hold everything else.
- Relative paths resolve from the config file's directory.
- A key that is not specified generates nothing.
- `loadKolayConfig` now returns `{ config, filepath }` so the config directory is known for path resolution.

**Dogfooded**: the docs-app now builds through `kolay()` itself — its vite.config.js is the one-plugin form and its kolay.config.js carries the groups, api docs, demos, import entrypoints, and redirects. The whole docs-app suite (85 passing) runs against that build, which exercises every generated plugin (both docs groups, typedoc, live demos, `#demos/site` imports, importEntrypoints fences, and the redirect acceptance tests).

Also: a new *Development → kolay.config.js* page documenting the keys and file forms, and 8 vitest tests for the config→plugins composition (per-entry docs usages, src resolution, markdownOptions sharing/overrides, absent keys generate nothing).

Full repo lint, vitest (163), and the docs-app suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

