### PR TITLE
fix(GroupNav): the Home link is the app root, not /Home

### DIFF
--- a/src/browser/components/group-nav.gts
+++ b/src/browser/components/group-nav.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
 import { docsManager } from '../services/docs.ts';
+import { HOME_GROUP } from '../utils.ts';
 
 import type RouterService from '@ember/routing/router-service';
 
@@ -65,8 +66,11 @@ export class GroupNav extends Component<{
 
   get groups() {
     return this.#docs.availableGroups.map((groupName) => {
-      if (groupName === 'root') {
-        return { text: this.homeName, value: '/', href: this.rootURL };
+      // The co-located pages are a group, but they live in the root URL
+      // space rather than under their name, so the link is the app's root
+      // and `@homeName` names it.
+      if (groupName === HOME_GROUP) {
+        return { text: this.homeName, value: HOME_GROUP, href: this.rootURL };
       }
 
       return {
@@ -79,13 +83,11 @@ export class GroupNav extends Component<{
     });
   }
 
-  isActive = (subPath: string) => {
-    if (subPath === '/') return false;
-
+  isActive = (groupName: string) => {
     // The group is derived from the URL by the docs service (rootURL-aware),
     // rather than comparing the group name against currentURL directly
     // (which always failed: 'Docs' never prefixes '/Docs/...').
-    return this.#docs.selectedGroup === subPath;
+    return this.#docs.selectedGroup === groupName;
   };
 
   get activeClass() {

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -4,6 +4,14 @@ import { getOwner } from '@ember/owner';
 import type { Page, PageTree } from '../types.ts';
 import type Owner from '@ember/owner';
 
+/**
+ * The co-located pages' group (app/templates, src/templates), as the build
+ * names it (`displayName` in build/plugins/setup.js's `homeSource`). Its
+ * pages live in the root URL space rather than under the group's name, so
+ * its nav link is the app's root.
+ */
+export const HOME_GROUP = 'Home';
+
 export function isPageTree(x: Page | PageTree): x is PageTree {
   return 'pages' in x;
 }

--- a/test-apps/markdown-only/tests/application-test.ts
+++ b/test-apps/markdown-only/tests/application-test.ts
@@ -29,28 +29,24 @@ module("All Links", function (hooks) {
       return new Promise((resolve) => setTimeout(resolve, 250));
     });
 
+    // The co-located pages' link is the app root now, rather than `/Home`
+    // where nothing is served — so the crawl no longer visits `/Home`, and
+    // the root sends it on to the first group.
     assert.verifySteps([
-      "/Home",
       "/Docs",
       "/my-folder-name/bar.md",
       "/my-folder-name/foo.md",
-      "/Home",
-      "/my-folder-name/bar.md",
-      "/Home",
+      "/Docs",
       "/Docs/sub-folder/ember-primitives.md",
       "/Docs/sub-folder/ember-resources.md",
-      "/Home",
-      "/my-folder-name/foo.md",
       "/Docs",
       "/my-folder-name/foo.md",
       "/my-folder-name/bar.md",
       "/Docs",
-      "/Home",
-      "/Home",
       "/Docs/sub-folder/ember-resources.md",
-      "/Docs",
       "/Docs/sub-folder/ember-primitives.md",
-      "/Home",
+      "/Docs",
+      "/Docs",
     ]);
   });
 });

--- a/test-apps/multiple-docs-routes/app/templates/application.gts
+++ b/test-apps/multiple-docs-routes/app/templates/application.gts
@@ -38,7 +38,7 @@ const SideNav: TOC<{ Element: HTMLElement }> = <template>
 
 <template>
   <header style="display: flex; align-items: baseline; gap: 1rem;">
-    <GroupNav />
+    <GroupNav @homeName="Docs Home" />
   </header>
 
   <div class="big-layout">

--- a/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
+++ b/test-apps/multiple-docs-routes/tests/multiple-docs-routes-test.gts
@@ -2,10 +2,6 @@ import { currentURL, render, visit } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupApplicationTest, setupRenderingTest } from "ember-qunit";
 
-// build-time resolution of a demos() alias: this import is compiled
-// like any other module in the app graph
-import Hello from "#demos/kit/hello";
-
 import { docsManager } from "kolay";
 import {
   manifest as demosManifest,
@@ -13,6 +9,10 @@ import {
   name as demosName,
 } from "virtual:kolay/docs/demos";
 import { meta as guidesMeta } from "virtual:kolay/docs/guides";
+
+// build-time resolution of a demos() alias: this import is compiled
+// like any other module in the app graph
+import Hello from "#demos/kit/hello";
 
 module("Multiple docs routes", function (hooks) {
   setupApplicationTest(hooks);
@@ -68,6 +68,19 @@ module("Multiple docs routes", function (hooks) {
 
     assert.dom("[data-page-error]").doesNotExist();
     assert.dom("h1").containsText("Welcome home");
+  });
+
+  test("the co-located pages' nav link is the app root, and @homeName names it", async function (assert) {
+    await visit("/welcome/home.md");
+
+    assert
+      .dom('header nav a[href="/"]')
+      .exists("links at the root, where the co-located pages live")
+      .hasText("Docs Home", "and @homeName is what names it")
+      .hasClass("active", "and reads active while reading one of them");
+    assert
+      .dom('header nav a[href="/Home"]')
+      .doesNotExist("not the group name: no page is served under it");
   });
 
   test("a .md page renders from the scoped /help mount (group: guides)", async function (assert) {


### PR DESCRIPTION
## The bug

`<GroupNav />`'s entry for the co-located pages links at `rootURL + 'Home'`. No page is served there: co-located pages (`app/templates` / `src/templates`) live in the *root* URL space, not under a group name.

One cause, in kolay: the branch that handles that entry tests for a group named **`'root'`**, and the build has named that group **`'Home'`** since `158bf9d` (`homeSource`'s `displayName`). So the branch never fires.

Two consequences:

1. **The link is wrong.** What that costs depends on the app: with [`handlePotentialIndexVisit`](/Runtime/navigation/handle-potential-index-visit.md) wired on the top-level wildcard route, `/Home` resolves the group by name and redirects to its first page — the reader gets there, via a URL that was never meant to exist and an extra history hop. Without it, `/Home` is a hard 404. Both are live in this repo today: `docs-app` wires it (`src/routes/page.ts`) and redirects; `test-apps/multiple-docs-routes` does not, and 404s.
2. **`@homeName` does nothing.** It is read at exactly one line — inside that dead branch — so the documented way to relabel this entry ("commonly set to the library name") has no effect.

Reproduced on **this repo's `main`**, not in a consumer app. `docs-app/src/templates/application.gts` with `<GroupNav @homeName="Kolay" />`:

```
Home -> /Home      ← @homeName ignored, link is /Home
Runtime -> /Runtime
TypeDoc -> /TypeDoc
```

## What I got wrong first time

My initial description claimed the entry also never reads active. **That was wrong** — because the dead branch leaves `value` as the group name, `isActive` compares `selectedGroup === 'Home'` and works fine. Corrected here; the fix keeps it working.

## The fix

```diff
-      if (groupName === 'root') {
-        return { text: this.homeName, value: '/', href: this.rootURL };
+      if (groupName === HOME_GROUP) {
+        return { text: this.homeName, value: HOME_GROUP, href: this.rootURL };
       }
```

`isActive`'s `if (subPath === '/') return false` goes with it — that guard existed only for the old sentinel `value`. `HOME_GROUP` is a new internal constant in `browser/utils.ts`, next to the build's own `'Home'`.

## Validation

- `test-apps/multiple-docs-routes` now passes `@homeName="Docs Home"` and asserts the entry links at `/`, is labeled **Docs Home**, reads active on a co-located page, and that nothing in the nav points at `/Home`. That test fails on `main` for the label and the href. 15/15 in that app.
- Manually, on `main` vs this branch, in kolay's own `docs-app` (the output above).
- `lint:js` / `lint:types` / prettier clean; `pnpm vitest --run src` unaffected (203).

## Notes

- Found while working on [#366](https://github.com/universal-ember/kolay/pull/366) (which touches this component), and split out so it can land on its own. It is also in that branch, so whichever merges first, the other rebases cleanly.
- Behavior change for any site using `<GroupNav />`: the entry's href goes from `/Home` to the app root, and a `@homeName` you had set starts taking effect. Worth a line in the v6 migration guide — [#366](https://github.com/universal-ember/kolay/pull/366) has one, which should move here if this lands first.
- Adjacent staleness of the same `'root'` sentinel, not fixed here — say the word and I will fold them in: `DocsService#selectGroup`'s `if (group === 'root')` branch (unreachable behind its own assert), `kolay/test-support`'s `selectGroup(context, groupName = 'root')` default, and `groupHrefFor('Home')` returning `/Home`, which is the deeper cause — fixing that would let `<GroupNav />` drop the special case entirely and keep only the `@homeName` label concern.

<sub>🤖 Fix by Claude Code (Opus 5, 1M context), pairing with @gitKrystan — found by probing what a nav entry's URL resolves to, verified in kolay's own docs-app and test app.</sub>
