### PR TITLE
fix: serve group roots in markdown-only

### DIFF
--- a/test-apps/markdown-only/app/routes/page.ts
+++ b/test-apps/markdown-only/app/routes/page.ts
@@ -1,0 +1,13 @@
+import Route from "@ember/routing/route";
+
+import { handlePotentialIndexVisit } from "kolay";
+
+import type RouterService from "@ember/routing/router-service";
+
+type Transition = ReturnType<RouterService["transitionTo"]>;
+
+export default class PageRoute extends Route {
+  beforeModel(transition: Transition) {
+    handlePotentialIndexVisit(this, transition);
+  }
+}

--- a/test-apps/markdown-only/tests/application-test.ts
+++ b/test-apps/markdown-only/tests/application-test.ts
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { currentURL, visit } from "@ember/test-helpers";
 import { module, skip, test } from "qunit";
 import { setupApplicationTest } from "ember-qunit";
 
@@ -19,25 +19,36 @@ module("PageNav", function (hooks) {
   });
 });
 
+module("Group index redirects", function (hooks) {
+  setupApplicationTest(hooks);
+
+  test("visiting a group root redirects to its first page", async function (assert) {
+    await visit("/Docs");
+
+    assert.strictEqual(
+      currentURL(),
+      "/Docs/sub-folder/ember-primitives.md",
+      "the Docs group index redirects to its first page",
+    );
+  });
+});
+
 module("All Links", function (hooks) {
   setupApplicationTest(hooks);
 
   skippable("are visitable without error", async function (assert) {
-    await visitAllLinks(async (path) => {
-      assert.step(path);
+    const visited: string[] = [];
 
-      return new Promise((resolve) => setTimeout(resolve, 250));
+    await visitAllLinks((path) => {
+      visited.push(path);
     });
 
-    // The co-located pages' link is the app root now, rather than `/Home`
-    // where nothing is served — so the crawl no longer visits `/Home`, and
-    // the root sends it on to the first group.
-    assert.verifySteps([
+    assert.deepEqual(visited.sort(), [
       "/Docs",
-      "/my-folder-name/bar.md",
-      "/my-folder-name/foo.md",
       "/Docs/sub-folder/ember-primitives.md",
       "/Docs/sub-folder/ember-resources.md",
+      "/my-folder-name/bar.md",
+      "/my-folder-name/foo.md",
     ]);
   });
 });


### PR DESCRIPTION
`markdown-only` is the last test-app without `handlePotentialIndexVisit`. Its `/Docs` group root errors on every run, and the suite reports green anyway.

Follow-up to #371, which found and fixed the same thing in `markdown-and-gjs-md-app`. I left this one alone there because it was already running in CI and the fix wasn't fallout from that rename.

## Why the crawl never caught it

`visitAllLinks` compares URLs. An erroring `/Docs` stays at `/Docs`, so `current.startsWith(expected)` holds and the navigation counts as successful. The only trace is a console line nothing asserts on:

```
Page not found for path "/Docs". (Using group: "Docs", see console for more information)
```

So the new test asserts the redirect directly rather than trusting the crawl to notice.

## Also here

The crawl moves to `assert.deepEqual(visited.sort(), [...])`, matching the other two apps after @NullVoxPopuli's review on #371. Its per-visit 250ms padding goes with it — that predates the test waiters 0d52f50 registered, and test-support 0.9.0 visits each target once. The crawl drops from 1296ms to 35ms.

## Overlap with #370

#370 makes group roots resolve through `routeWillChange`, so once it lands `/Docs` here redirects without a route file and the `app/routes/page.ts` added below becomes a no-op.

Keeping it anyway, because the merge order isn't fixed: on `main` as it stands today the route is what fixes the bug, so dropping it would make this PR silently depend on #370 landing first. It stays harmless afterwards — every other test-app still wires the hook.

The rest of this PR is unaffected, and the direct redirect assertion gets more useful under #370, not less: it becomes the only thing that would catch group-root redirects regressing.

## Checked and not changed

`docs-app` passes `skipAllLinks`, and I'd guessed in #371 that 0.9.0 might have made that unnecessary. It hasn't: with the flag off, the crawl hits its 120s timeout and the next three tests then fail at 180s each. Left as-is.

That leaves no test-app with a group root that errors.

## Testing

`markdown-only` goes from 3 tests to 4, all green:

```
pnpm build                 # once, at the root
cd test-apps/markdown-only && pnpm build:tests && pnpm test:browser
```

To see the bug, check out `main` and watch the browser log during that run — `Page not found for path "/Docs"`, with the suite still green.

<sub>**AI attribution:** :robot: _Claude using Opus 5. Used skills including `pr-description` and `humanizer`. The author chose the scope; neither the code nor this description has been reviewed by them yet. Opened as a draft for that reason._</sub>

