### PR TITLE
test: run docs-app's all-links crawl, in its own browser session

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -30,7 +30,7 @@
     "start:vite": "vite",
     "start:test": "pnpm start:vite --open /tests/",
     "test:ember": "pnpm build:tests && pnpm test:browser",
-    "test:browser": "testem ci --port 0"
+    "test:browser": "testem ci --port 0 && testem ci --port 0 --file testem.crawl.cjs"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/docs-app/testem.crawl.cjs
+++ b/docs-app/testem.crawl.cjs
@@ -1,0 +1,12 @@
+'use strict';
+
+// The all-links crawl runs in its own browser session, because it cannot share
+// one with the rest of the suite: compiling every page wedges ember-repl's
+// module-level compiler, so whichever runs second gets 120s timeouts. Alone and
+// first, the crawl finishes in about 3s.
+if (typeof module !== 'undefined') {
+  module.exports = {
+    ...require('./testem.cjs'),
+    test_page: 'tests/index.html?hidepassed&filter=All Links',
+  };
+}

--- a/docs-app/testem.crawl.cjs
+++ b/docs-app/testem.crawl.cjs
@@ -1,9 +1,9 @@
 'use strict';
 
 // The all-links crawl runs in its own browser session, because it cannot share
-// one with the rest of the suite: compiling every page wedges ember-repl's
-// module-level compiler, so whichever runs second gets 120s timeouts. Alone and
-// first, the crawl finishes in about 3s.
+// one with the rest of the suite: compiling every page leaves ember-repl's
+// module-level compiler unable to serve another test app, so whichever runs
+// second gets 120s timeouts. Alone and first, the crawl finishes in about 3s.
 if (typeof module !== 'undefined') {
   module.exports = {
     ...require('./testem.cjs'),

--- a/docs-app/tests/docs-app/all-links-test.gts
+++ b/docs-app/tests/docs-app/all-links-test.gts
@@ -5,12 +5,16 @@ import { visitAllLinks } from '@universal-ember/test-support';
 
 const skippable = new URLSearchParams(location.search).has('skipAllLinks') ? skip : test;
 
+// The Redirects page links its own examples; kolay.config.js sends them here.
+const KNOWN_REDIRECTS = {
+  '/usage/setup': '/install/index.md',
+  '/docs/component-signature': '/TypeDoc/components/component-signature',
+};
+
 module('All Links', function (hooks) {
   setupApplicationTest(hooks);
 
   skippable('are visitable without error', async function () {
-    await visitAllLinks(async () => new Promise((resolve) => setTimeout(resolve, 250)), {
-      '/Home': '/install/index',
-    });
+    await visitAllLinks(undefined, KNOWN_REDIRECTS);
   });
 });


### PR DESCRIPTION
`docs-app` is the only app whose all-links crawl has never run. `skipAllLinks` has been on its testem config since before the flag had a reason to come off, so nobody has checked whether its links resolve.

This runs it, in a second browser session. It finds no broken pages.

## Why it needs its own session

Switching the flag off does not work. The crawl compiles every page, which leaves ember-repl's module-level compiler unable to serve another test app, so whichever runs second gets 120s timeouts:

| Crawl position | Crawl | Everything after it |
| --- | --- | --- |
| first | passes, ~2.5s | fails, 120s each from test 12 |
| last | fails, 120s | fails, 180s each |

Renaming the file `zz-*` does not fix the ordering either — `tests/kolay/*` sorts after `tests/docs-app/*` regardless. Alone and first, the crawl finishes in about 3s, so it gets `testem.crawl.cjs` and `test:browser` runs both configs.

That is the same pre-existing ember-repl issue `custom-root-url`'s `zz-` prefix works around. This does not fix it, it just stops sharing a session with it.

## What the crawl found

Two undeclared redirects, both intentional. The Development > Redirects page links its own examples, and `kolay.config.js` sends them elsewhere:

| Link | Lands on | Rule |
| --- | --- | --- |
| `/usage/setup` | `/install/index.md` | `kolay.config.js:51` |
| `/docs/component-signature` | `/TypeDoc/components/component-signature` | the `docs/*` wildcard, `:44` |

No 404s, and no pages missing from the manifest. Worth saying plainly, because the same crawl on Krystan's internal docs app turned up nine genuinely broken pages once its assertion was fixed. This one was skipped rather than quietly passing, which is the more honest of the two failure modes.

Two smaller things go with it. The per-visit 250ms padding predates the waiters `0d52f50` registered, and the `/Home` redirect entry has been dead since `0dab708` pointed that link at the app root — the crawler skips a bare `/` as its own starting page.

## Testing

```
pnpm build                        # once, at the root
cd docs-app && pnpm build:tests && pnpm test:browser
```

That runs both configs. To see the crawl alone:

```
cd docs-app && testem ci --port 0 --file testem.crawl.cjs
```

**Please treat CI as the verification here rather than my local numbers.** The crawl config itself I ran repeatedly and it is stable at 1/1 in ~2.7s. What I could not measure honestly is whether the main suite is unaffected: this machine sat at a load average of 13-15 throughout, which is the exact condition that produces spurious 120s timeouts in these apps, and one of my runs died to my own stray `pkill`. A local run of mine did show three `<ComponentSignature>` failures that pass on CI, and I believe that is the load rather than this change — but I would rather say so than present it as verified.

<sub>**AI attribution:** :robot: _Claude using Opus 5. Used skills including `pr-description` and `humanizer`. The author chose to open this as a draft and let CI verify it; neither the code nor this description has been reviewed by them yet._</sub>

