### PR TITLE
test: run docs-app's all-links crawl

### DIFF
--- a/docs-app/testem.cjs
+++ b/docs-app/testem.cjs
@@ -2,7 +2,7 @@
 
 if (typeof module !== 'undefined') {
   module.exports = {
-    test_page: 'tests/index.html?hidepassed&skipAllLinks',
+    test_page: 'tests/index.html?hidepassed',
     cwd: 'dist',
     disable_watching: true,
     launch_in_ci: ['Chrome'],

--- a/docs-app/tests/docs-app/all-links-test.gts
+++ b/docs-app/tests/docs-app/all-links-test.gts
@@ -5,12 +5,16 @@ import { visitAllLinks } from '@universal-ember/test-support';
 
 const skippable = new URLSearchParams(location.search).has('skipAllLinks') ? skip : test;
 
+// The Redirects page links its own examples; kolay.config.js sends them here.
+const KNOWN_REDIRECTS = {
+  '/usage/setup': '/install/index.md',
+  '/docs/component-signature': '/TypeDoc/components/component-signature',
+};
+
 module('All Links', function (hooks) {
   setupApplicationTest(hooks);
 
   skippable('are visitable without error', async function () {
-    await visitAllLinks(async () => new Promise((resolve) => setTimeout(resolve, 250)), {
-      '/Home': '/install/index',
-    });
+    await visitAllLinks(undefined, KNOWN_REDIRECTS);
   });
 });


### PR DESCRIPTION
`docs-app` is the only app that skips its all-links crawl, so nothing has checked that its links resolve. This takes `skipAllLinks` off and runs it, where every other app already runs one.

Two files, eight lines.

## What you're getting for it

The crawl finds **no broken pages**. It does find two links the Development > Redirects page makes as examples of itself, which `kolay.config.js` sends elsewhere:

| Link | Lands on | Rule |
| --- | --- | --- |
| `/usage/setup` | `/install/index.md` | `kolay.config.js:51` |
| `/docs/component-signature` | `/TypeDoc/components/component-signature` | the `docs/*` wildcard, `:44` |

Both are declared now. So this is coverage against future broken links rather than a fix for a present one — which is a fair thing to decline.

Two smaller cleanups ride along. The per-visit 250ms padding predates the waiters `0d52f50` registered, and the `/Home` redirect entry has been dead since `0dab708` pointed that link at the app root, which the crawler skips as its own starting page.

## Replacing #374

@NullVoxPopuli closed [#374](https://github.com/universal-ember/kolay/pull/374), which wrapped the same idea in a second testem config and a chained `test:browser`. He was right to. The justification for that machinery was a claim that the crawl cannot share a browser session with the rest of the suite, and I could not support it:

- Every local run behind it sat at a load average of 13-15. That same machine produced three `<ComponentSignature>` failures that pass on CI, so it manufactures 120s timeouts unprompted.
- I never ran `docs-app` with the crawl on in a single session on a clean machine, which is the only measurement that settles it.
- His reading is that it makes no sense anyway, since testem loads one test-app at a time.

So this drops the machinery and just runs the crawl. CI on this PR is the measurement I should have taken first.

## Testing

```
pnpm build                        # once, at the root
cd docs-app && pnpm build:tests && pnpm test:browser
```

Locally the crawl takes about 3s over 69 pages; on CI it was 6.2s.

<sub>**AI attribution:** :robot: _Claude using Opus 5. Used skills including `pr-description` and `humanizer`. Krystan asked for this minimal version after #374 was closed; neither the code nor this description has been reviewed by her yet, which is why it is a draft._</sub>
