### PR TITLE
Pick up markdown at the root of a docs source

### DIFF
--- a/docs-app/src/templates/development/configuring-docs.gjs.md
+++ b/docs-app/src/templates/development/configuring-docs.gjs.md
@@ -119,6 +119,26 @@ There are a few ways you can collect docs:
 - co-located pages: anything in `app/templates` / `src/templates` is picked up automatically (no group, served from the root URL space) — even with zero-argument `docs()`.
 - a group per `docs()` usage: the `src` can point at a `docs` folder anywhere in (or outside) your project — including another package's `components` folder, picking up all markdown found there. This is useful for co-locating docs with their implementations.
 
+### Pages at the root of a source
+
+Markdown does not have to live in a folder. A file at the root of a source is a page of the group itself, and it sits in `<PageNav />` next to the folders:
+
+```
+docs/
+  intro.md        -> /GroupName/intro.md
+  guides/
+    advanced.md   -> /GroupName/guides/advanced.md
+```
+
+The same is true of the co-located pages: `src/templates/welcome.md` is served at `/welcome.md`.
+
+Two things follow from this:
+
+- Root-level pages take part in the source's `meta.json` [`order`](/development/ordering-pages.md) next to the folder names. An `order` there must list all of them.
+- An `index.md` at the root is the group's first page — where a visit to the group's URL lands. Like a folder's `index.md`, it gets no separate link in `<PageNav />`; the group's own link in `<GroupNav />` points at it.
+
+A page cannot share a name with a sibling folder (`intro.md` next to an `intro/` folder), at the root or anywhere else. The build fails with a message telling you which file to move.
+
 ## Using the plugin multiple times
 
 `docs()` is used once per group — so multiple groups means multiple usages, each with its own markdown processing (`remarkPlugins`, `rehypePlugins`, `scope`) if needed:

--- a/docs-app/src/templates/development/ordering-pages.gjs.md
+++ b/docs-app/src/templates/development/ordering-pages.gjs.md
@@ -27,6 +27,17 @@ We can create a `meta.jsonc` file at `public/docs/meta.jsonc`:
 
 With `jsonc`, we can have comments to explain our reasoning for having configuration at all, and now when rendering the navigation at runtime, we can have `Usage` rendered above `Plugins` without needing to implement any runtime code to do this for us.
 
+Markdown files that sit at the root of the source — next to the folders, rather than in one — are sorted by the same `order`. List them by file name without the extension:
+
+```jsonc
+{
+  // intro.md is a page at the root; usage and plugins are folders
+  "order": ["intro", "usage", "plugins"],
+}
+```
+
+An `order` must name every page and folder at that level, so adding a root-level page means adding it here too.
+
 ### Sorting pages
 
 For example, in this project, the pages under `usage` appear alphabetically in the filesystem like this:

--- a/src/build/plugins/markdown-pages/parse.build.test.ts
+++ b/src/build/plugins/markdown-pages/parse.build.test.ts
@@ -181,6 +181,127 @@ describe('build', () => {
     `);
   });
 
+  describe('pages at the source root', () => {
+    test('a single top-level page', () => {
+      const result = build([{ mdPath: 'intro.md' }]);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "name": "root",
+          "pages": [
+            {
+              "cleanedName": "intro",
+              "groupName": "",
+              "name": "intro",
+              "path": "/intro.md",
+            },
+          ],
+          "path": "root",
+        }
+      `);
+    });
+
+    test('top-level pages sit alongside folders', () => {
+      const result = build([
+        { mdPath: 'some-folder/nested.md' },
+        { mdPath: 'about.md' },
+        { mdPath: 'index.md' },
+      ]);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "name": "root",
+          "pages": [
+            {
+              "cleanedName": "some folder",
+              "name": "some-folder",
+              "pages": [
+                {
+                  "cleanedName": "nested",
+                  "groupName": "some folder",
+                  "name": "nested",
+                  "path": "/some-folder/nested.md",
+                },
+              ],
+              "path": "some-folder",
+            },
+            {
+              "cleanedName": "about",
+              "groupName": "",
+              "name": "about",
+              "path": "/about.md",
+            },
+            {
+              "cleanedName": "index",
+              "groupName": "",
+              "name": "index",
+              "path": "/index.md",
+            },
+          ],
+          "path": "root",
+        }
+      `);
+    });
+
+    test('a top-level gjs.md page keeps the double extension out of the path', () => {
+      const result = build([{ mdPath: 'intro.gjs.md' }]);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "name": "root",
+          "pages": [
+            {
+              "cleanedName": "intro",
+              "groupName": "",
+              "name": "intro",
+              "path": "/intro",
+            },
+          ],
+          "path": "root",
+        }
+      `);
+    });
+
+    test('a top-level page keeps its config', () => {
+      const result = build([{ mdPath: 'intro.md', config: { title: 'Introduction' } }]);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "name": "root",
+          "pages": [
+            {
+              "cleanedName": "intro",
+              "groupName": "",
+              "name": "intro",
+              "path": "/intro.md",
+              "title": "Introduction",
+            },
+          ],
+          "path": "root",
+        }
+      `);
+    });
+
+    test('a leading ./ does not become a folder', () => {
+      const result = build([{ mdPath: './intro.md' }]);
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "name": "root",
+          "pages": [
+            {
+              "cleanedName": "intro",
+              "groupName": "",
+              "name": "intro",
+              "path": "/intro.md",
+            },
+          ],
+          "path": "root",
+        }
+      `);
+    });
+  });
+
   describe('validation', () => {
     test('cannot have named and index at the same time', () => {
       expect(() => {
@@ -195,6 +316,14 @@ describe('build', () => {
         build([{ mdPath: 'top/deep/another.md' }, { mdPath: 'top/deep/another/index.md' }]);
       }).toThrowError(
         'Cannot have a group that matches the name of an individual page. Please move another.md into the "/top/deep/another" folder. If you want this to be the first page, rename the file to top/deep/another/index.md'
+      );
+    });
+
+    test('a top-level page cannot match the name of a top-level folder', () => {
+      expect(() => {
+        build([{ mdPath: 'guides/index.md' }, { mdPath: 'guides.md' }]);
+      }).toThrowError(
+        'Cannot have a group that matches the name of an individual page. Please move guides.md into the "guides" folder. If you want this to be the first page, rename the file to guides/index.md'
       );
     });
   });

--- a/src/build/plugins/markdown-pages/parse.js
+++ b/src/build/plugins/markdown-pages/parse.js
@@ -72,21 +72,18 @@ export function build(docs, populate) {
   for (let { mdPath, config, frontmatter } of docs) {
     const sourcePath = mdPath;
 
-    if (!mdPath.includes('/')) {
-      console.warn(
-        `markdown path, ${mdPath}, is not contained within a folder. It will be skipped.`
-      );
-      continue;
-    }
-
     mdPath = mdPath.replace(/^\.\/(src|app)\/templates\//, '');
     mdPath = mdPath.replace(/^\.\.\//, '');
+    mdPath = mdPath.replace(/^\.\//, '');
 
     const parts = mdPath.split('/');
     const [name, ...reversedGroups] = parts.reverse();
+    /**
+     * Empty for a file at the root of the source — the page then belongs
+     * to the source itself rather than to a folder within it.
+     */
     const groups = reversedGroups.reverse();
 
-    if (groups.length === 0) continue;
     if (!name) continue;
 
     /** @type {import('./types.ts').PageTree} */
@@ -130,12 +127,13 @@ export function build(docs, populate) {
       leafestGroupName = group;
     }
 
-    assert(
-      leafestGroupName,
-      'Could not determine group name. A group / folder is required for each file.'
-    );
-
-    const groupName = cleanSegment(leafestGroupName);
+    /**
+     * A page at the root of the source has no containing folder, so it has
+     * no folder name to take a groupName from. The source's own display
+     * name is not known here (it comes from the docs() config), so this is
+     * left empty rather than guessed at.
+     */
+    const groupName = leafestGroupName ? cleanSegment(leafestGroupName) : '';
     const cleanedName = cleanSegment(name);
     const path = '/' + mdPath.replace(/\.g(j|t)s\.md$/, '');
 
@@ -239,10 +237,6 @@ async function gather(paths, cwd, providedConfigs, options) {
   const docPairs = [];
 
   for (const path of markdown) {
-    if (!path.includes('/')) {
-      continue;
-    }
-
     docPairs.push({ mdPath: path, config: configFor(path), frontmatter: frontmatterFor(path) });
   }
 
@@ -253,7 +247,6 @@ async function gather(paths, cwd, providedConfigs, options) {
    * in another group.
    */
   for (const entry of configs) {
-    if (!entry.path.includes('/')) continue;
     if (/(^|\/)meta\.jsonc?$/.test(entry.path)) continue;
     if (typeof entry.config.href !== 'string') continue;
 

--- a/src/build/plugins/markdown-pages/parse.rootPages.test.ts
+++ b/src/build/plugins/markdown-pages/parse.rootPages.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest';
+
+import { addPaths } from './hydrate.js';
+import { parse } from './parse.js';
+import { sortTree } from './sort.js';
+
+const cwd = '/definitely/not/read/from';
+
+type Node = Record<string, unknown> & { name: string };
+type Tree = { pages: Array<Node & { pages?: Node[] }> };
+
+describe('markdown at the root of a source', () => {
+  test('a top-level page is gathered, not skipped', async () => {
+    const tree = (await parse(['intro.md'], cwd, [])) as unknown as Tree;
+
+    expect(tree.pages.map((node) => node.name)).toEqual(['intro']);
+  });
+
+  test('top-level pages and folders live side by side, and sort together', async () => {
+    const tree = (await parse(
+      ['guides/getting-started.md', 'about.md', 'index.md', 'x-last.md'],
+      cwd,
+      []
+    )) as unknown as Tree;
+
+    // a top-level index is the source's first page, and `x-` still sorts last —
+    // the same ordering rules folders get
+    expect(tree.pages.map((node) => node.name)).toEqual(['index', 'guides', 'about', 'x-last']);
+
+    const guides = tree.pages.find((node) => node.name === 'guides');
+
+    expect(guides?.pages?.map((node) => node.name)).toEqual(['getting-started']);
+  });
+
+  test('a top-level json config applies to its top-level page', async () => {
+    const tree = (await parse(['intro.md', 'intro.json'], cwd, [
+      { path: 'intro.json', config: { title: 'Introduction' } },
+    ])) as unknown as Tree;
+
+    const page = tree.pages.find((node) => node.name === 'intro');
+
+    expect(page?.title).toBe('Introduction');
+  });
+
+  test("a top-level meta.json is the source's own config, not a page", async () => {
+    const tree = (await parse(['intro.md', 'meta.json'], cwd, [
+      { path: 'meta.json', config: { order: ['intro'] } },
+    ])) as unknown as Tree;
+
+    expect(tree.pages.map((node) => node.name)).toEqual(['intro']);
+  });
+
+  test('a top-level json with an href (and no page of its own) is a nav-only link entry', async () => {
+    const tree = (await parse(['elsewhere.json'], cwd, [
+      { path: 'elsewhere.json', config: { href: '/TypeDoc/plugin/api-docs.md' } },
+    ])) as unknown as Tree;
+
+    const link = tree.pages.find((node) => node.name === 'elsewhere');
+
+    expect(link?.href).toBe('/TypeDoc/plugin/api-docs.md');
+  });
+
+  test("a root meta.json's order can place a top-level page among the folders", async () => {
+    const configs = [{ path: 'meta.json', config: { order: ['about', 'guides'] } }];
+
+    let tree = await parse(['guides/index.md', 'about.md', 'meta.json'], cwd, configs);
+
+    tree = sortTree(tree, configs);
+
+    expect((tree as unknown as Tree).pages.map((node) => node.name)).toEqual(['about', 'guides']);
+  });
+
+  test('a top-level page gets the group prefix and the base', async () => {
+    const tree = (await parse(['intro.md'], cwd, [])) as unknown as Tree;
+
+    addPaths(tree as unknown as Parameters<typeof addPaths>[0], '/Documentation', '/my-app/');
+
+    const page = tree.pages.find((node) => node.name === 'intro');
+
+    expect(page?.appRelativePath).toBe('/Documentation/intro.md');
+    expect(page?.path).toBe('/my-app/Documentation/intro.md');
+  });
+
+  test('the co-located pages root (app/src templates) may hold top-level pages', async () => {
+    const tree = (await parse(
+      ['./src/templates/index.md', './src/templates/guides/nested.md'],
+      cwd,
+      []
+    )) as unknown as Tree;
+
+    expect(tree.pages.map((node) => node.name)).toEqual(['index', 'guides']);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,11 @@ export interface Page {
    */
   appRelativePath: string;
   name: string;
+  /**
+   * The cleaned name of the folder the page is in, e.g. 'sub folder'.
+   * Empty for a page at the root of its source — there is no folder to
+   * name it after.
+   */
   groupName: string;
   cleanedName: string;
   /**

--- a/test-apps/custom-root-url/docs/top.md
+++ b/test-apps/custom-root-url/docs/top.md
@@ -1,0 +1,3 @@
+# Top level
+
+This page lives at the root of the docs source, alongside the folders, rather than in a folder of its own.

--- a/test-apps/custom-root-url/tests/index-redirect-test.ts
+++ b/test-apps/custom-root-url/tests/index-redirect-test.ts
@@ -18,7 +18,7 @@ module("Group index redirects under a custom rootURL", function (hooks) {
     await visit("/Documentation");
     assert.strictEqual(
       currentURL(),
-      "/Documentation/sub-folder/lonely-page.md",
+      "/Documentation/top.md",
       "the Documentation group index redirects to its first page (rootURL stripped)",
     );
   });
@@ -34,7 +34,7 @@ module("Group index redirects under a custom rootURL", function (hooks) {
     await visit("/Documentation/");
     assert.strictEqual(
       currentURL(),
-      "/Documentation/sub-folder/lonely-page.md",
+      "/Documentation/top.md",
       "trailing slash doesn't break the redirect",
     );
   });
@@ -50,7 +50,7 @@ module("Group index redirects under a custom rootURL", function (hooks) {
     await visit("/DOCUMENTATION");
     assert.strictEqual(
       currentURL(),
-      "/Documentation/sub-folder/lonely-page.md",
+      "/Documentation/top.md",
       "the group name is matched case-insensitively",
     );
   });

--- a/test-apps/custom-root-url/tests/zz-all-links-crawl-test.ts
+++ b/test-apps/custom-root-url/tests/zz-all-links-crawl-test.ts
@@ -15,7 +15,7 @@ const skippable = new URLSearchParams(location.search).has("skipAllLinks") ? ski
 // Group index links redirect to the group's first page (via
 // `handlePotentialIndexVisit`), so tell the crawler where each one lands.
 const KNOWN_REDIRECTS = {
-  "/my-github-project/Documentation": "/my-github-project/Documentation/sub-folder/lonely-page.md",
+  "/my-github-project/Documentation": "/my-github-project/Documentation/top.md",
 };
 
 module("All Links", function (hooks) {
@@ -36,6 +36,7 @@ module("All Links", function (hooks) {
       "/my-github-project/Documentation/sub-folder/ember-primitives.md",
       "/my-github-project/Documentation/sub-folder/ember-resources",
       "/my-github-project/Documentation/sub-folder/lonely-page.md",
+      "/my-github-project/Documentation/top.md",
       "/my-github-project/my-folder-name/bar.md",
       "/my-github-project/my-folder-name/baz",
       "/my-github-project/my-folder-name/foo",

--- a/test-apps/markdown-and-gjs-md-app/docs/top.md
+++ b/test-apps/markdown-and-gjs-md-app/docs/top.md
@@ -1,0 +1,3 @@
+# Top level
+
+This page lives at the root of the docs source, alongside the folders, rather than in a folder of its own.

--- a/test-apps/markdown-and-gjs-md-app/tests/application-test.ts
+++ b/test-apps/markdown-and-gjs-md-app/tests/application-test.ts
@@ -16,7 +16,7 @@ module("Group index redirects", function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      "/Docs/sub-folder/ember-primitives.md",
+      "/Docs/top.md",
       "the Docs group index redirects to its first page",
     );
   });
@@ -55,6 +55,7 @@ module("All Links", function (hooks) {
       "/Docs",
       "/Docs/sub-folder/ember-primitives.md",
       "/Docs/sub-folder/ember-resources",
+      "/Docs/top.md",
       "/my-folder-name/bar.md",
       "/my-folder-name/baz",
       "/my-folder-name/foo",

--- a/test-apps/markdown-only/docs/top.md
+++ b/test-apps/markdown-only/docs/top.md
@@ -1,0 +1,3 @@
+# Top level
+
+This page lives at the root of the docs source, alongside the folders, rather than in a folder of its own.

--- a/test-apps/markdown-only/tests/application-test.ts
+++ b/test-apps/markdown-only/tests/application-test.ts
@@ -29,7 +29,7 @@ module("Group index redirects", function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      "/Docs/sub-folder/ember-primitives.md",
+      "/Docs/top.md",
       "the Docs group index redirects to its first page",
     );
   });
@@ -55,6 +55,22 @@ module("Frontmatter", function (hooks) {
   });
 });
 
+module("Pages at the root of a docs source", function (hooks) {
+  setupApplicationTest(hooks);
+
+  // docs/top.md has no folder of its own: it belongs to the source itself,
+  // and sits in the nav next to the folders.
+  test("a top-level markdown file is a page", async function (assert) {
+    await visit("/Docs/top.md");
+    await waitUntil(() => !document.querySelector(".loading-page"), { timeout: 5000 });
+
+    assert.dom("h1").hasText("Top level", "the top-level page's content is rendered");
+    assert
+      .dom('nav[aria-label="Selected Group"] a[href="/Docs/top.md"]')
+      .exists("the top-level page is linked from the page nav");
+  });
+});
+
 module("All Links", function (hooks) {
   setupApplicationTest(hooks);
 
@@ -69,6 +85,7 @@ module("All Links", function (hooks) {
       "/Docs",
       "/Docs/sub-folder/ember-primitives.md",
       "/Docs/sub-folder/ember-resources.md",
+      "/Docs/top.md",
       "/my-folder-name/bar.md",
       "/my-folder-name/foo.md",
     ]);


### PR DESCRIPTION
A `.md` file sitting directly in a `docs()` source was silently dropped. Only markdown inside a folder became a page. Now a root-level file is a page of the group itself, in the nav next to the folders.

```
docs/
  intro.md        -> /GroupName/intro.md     (was: warned about, then skipped)
  guides/
    advanced.md   -> /GroupName/guides/advanced.md
```

Same for the co-located pages: `src/templates/welcome.md` is served at `/welcome.md`.

## What changed

`src/build/plugins/markdown-pages/parse.js`:

- `build()` puts a page with no folder segments at the root of the tree, instead of `console.warn` + `continue`
- `gather()` no longer skips root-level markdown, or a root-level nav-only link entry (a json with an `href` and no page of its own). A root `meta.json` is still the source's own config, not a page
- a leading `./` no longer turns into a folder named `.`

A root-level page's `groupName` is `''`. There is no folder to name it after, and the source's display name lives in the `docs()` config, a layer above `build()`. Documented on `Page` in `src/types.ts`. Nothing reads it for layout: search entries get the group's display name from `setup.js`, and `docsManager` derives a page's group from its path.

## Consequences worth knowing

- Root-level pages take part in the source's `meta.json` `order` alongside the folder names. A source that already has an `order` and a stray root-level `README.md` will now fail the build until that file is listed (or moved out of the source).
- A root-level `index.md` becomes the group's first page and, like a folder's `index.md`, gets no separate `<PageNav />` link. The group's own `<GroupNav />` link points at it.
- The existing "a page cannot share a name with a sibling folder" check applies at the root too.

## Tests

- `parse.build.test.ts`: root-level page, mixed with folders, `.gjs.md`, per-page config, leading `./`, and the name-collides-with-a-folder error
- `parse.rootPages.test.ts` (new): through `parse()` and `sortTree()`, so it covers gathering, sorting, a root `meta.json` `order` that includes a root-level page, a root-level `href` link entry, and `app/src/templates` paths
- all five test apps pass in Chrome. The three that already had an empty, silently skipped `docs/top.md` now have content in it, so it is a real page and (by the existing sort rules) each group's first page. The index-redirect and all-links expectations move with it.
- `docs-app` builds

Docs: a "Pages at the root of a source" section in `docs()` configuration, and a note in Ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
