### PR TITLE
Forward per-format compiler options from setup()

### DIFF
--- a/src/browser/services/docs.ts
+++ b/src/browser/services/docs.ts
@@ -43,6 +43,7 @@ export function compilerOptions({
   remarkPlugins,
   rehypePlugins,
   modules,
+  formatOptions,
 }: {
   /**
    * The app's rootURL, so authored root-absolute URLs are rebased onto it.
@@ -54,6 +55,7 @@ export function compilerOptions({
   modules?: ModuleMap;
   remarkPlugins?: unknown[];
   rehypePlugins?: unknown[];
+  formatOptions?: Record<string, Record<string, unknown>>;
 } = {}) {
   const md = {
     /**
@@ -78,15 +80,23 @@ export function compilerOptions({
     ...topLevelScope,
   };
 
+  const { md: userMd, gmd: userGmd, hbs: userHbs, ...otherFormats } = formatOptions ?? {};
+
   return {
     options: {
-      md,
+      ...otherFormats,
+      md: {
+        ...md,
+        ...userMd,
+      },
       gmd: {
         scope,
         ...md,
+        ...userGmd,
       },
       hbs: {
         scope,
+        ...userHbs,
       },
     },
     modules: {
@@ -173,6 +183,18 @@ class DocsService {
      * These can be used to add features syntax-highlighting to pre elements, etc
      */
     rehypePlugins?: unknown[];
+
+    /**
+     * Per-format compiler options, keyed by format (`gjs`, `gmd`, `hbs`, `md`, ...),
+     * forwarded to the underlying compilers. Entries merge over the options kolay
+     * configures for each format, so e.g. `{ gjs: { owner } }` sets the owner that
+     * rendered `gjs` snippets resolve `getOwner(...)` lookups through.
+     *
+     * For adding remark/rehype plugins, prefer the dedicated `remarkPlugins` /
+     * `rehypePlugins` options, which compose with kolay's own plugins instead of
+     * replacing them.
+     */
+    formatOptions?: Record<string, Record<string, unknown>>;
   }) => {
     const [apiDocs, compiledDocs] = await Promise.all([options.apiDocs, options.compiledDocs]);
 
@@ -184,6 +206,7 @@ class DocsService {
       remarkPlugins: options.remarkPlugins ?? [],
       rehypePlugins: options.rehypePlugins ?? [],
       modules: options.modules,
+      formatOptions: options.formatOptions,
     });
 
     setupCompiler(this, optionsForCompiler);

--- a/src/browser/virtual/references.d.ts
+++ b/src/browser/virtual/references.d.ts
@@ -39,6 +39,18 @@ declare module 'kolay/setup' {
        * These can be used to add features syntax-highlighting to pre elements, etc
        */
       rehypePlugins?: unknown[];
+
+      /**
+       * Per-format compiler options, keyed by format (`gjs`, `gmd`, `hbs`, `md`, ...),
+       * forwarded to the underlying compilers. Entries merge over the options kolay
+       * configures for each format, so e.g. `{ gjs: { owner } }` sets the owner that
+       * rendered `gjs` snippets resolve `getOwner(...)` lookups through.
+       *
+       * For adding remark/rehype plugins, prefer the dedicated `remarkPlugins` /
+       * `rehypePlugins` options, which compose with kolay's own plugins instead of
+       * replacing them.
+       */
+      formatOptions?: Record<string, Record<string, unknown>>;
     }
   ): Promise<Manifest>;
 }

--- a/test-apps/markdown-and-gjs-md-app/app/routes/application.ts
+++ b/test-apps/markdown-and-gjs-md-app/app/routes/application.ts
@@ -1,9 +1,34 @@
+import { getOwner } from "@ember/owner";
 import Route from "@ember/routing/route";
 
 import { setupKolay } from "kolay/setup";
 
 export default class ApplicationRoute extends Route {
   async model() {
-    await setupKolay(this, {});
+    const appOwner = getOwner(this);
+
+    /**
+     * Exercises `formatOptions`: compiled pages and live snippets resolve
+     * their `getOwner(...)` lookups through this owner instead of the
+     * default app-delegating one. The probe key is read by
+     * owner-probe.gjs.md; everything else falls through to the app so
+     * other pages behave normally.
+     */
+    const probeOwner = {
+      lookup: (name: string) => {
+        if (name === "kolay-test:probe") {
+          return "from-custom-owner";
+        }
+
+        return appOwner?.lookup(name as `${string}:${string}`);
+      },
+    };
+
+    await setupKolay(this, {
+      formatOptions: {
+        gjs: { owner: probeOwner },
+        gmd: { owner: probeOwner },
+      },
+    });
   }
 }

--- a/test-apps/markdown-and-gjs-md-app/app/templates/my-folder-name/owner-probe.md
+++ b/test-apps/markdown-and-gjs-md-app/app/templates/my-folder-name/owner-probe.md
@@ -1,0 +1,21 @@
+# Owner probe
+
+This page is plain markdown, so it and its live snippet render through the
+runtime compilers — the snippet's component resolves `getOwner(...)` through
+the owner configured by the application route's `formatOptions`. (A `.gjs.md`
+page would compile at build time and never consult the runtime compiler.)
+
+```gjs live no-shadow
+import Component from "@glimmer/component";
+import { getOwner } from "@ember/owner";
+
+export default class OwnerProbe extends Component {
+  get probed() {
+    return getOwner(this)?.lookup("kolay-test:probe");
+  }
+
+  <template>
+    <span data-owner-probe>{{this.probed}}</span>
+  </template>
+}
+```

--- a/test-apps/markdown-and-gjs-md-app/tests/application-test.ts
+++ b/test-apps/markdown-and-gjs-md-app/tests/application-test.ts
@@ -41,6 +41,23 @@ module("Frontmatter", function (hooks) {
   });
 });
 
+module("formatOptions", function (hooks) {
+  setupApplicationTest(hooks);
+
+  test("a per-format owner reaches components rendered by the compiler", async function (assert) {
+    await visit("/my-folder-name/owner-probe.md");
+    await waitUntil(() => !document.querySelector(".loading-page"), { timeout: 5000 });
+    await waitUntil(() => document.querySelector("[data-owner-probe]"), { timeout: 5000 });
+
+    assert
+      .dom("[data-owner-probe]")
+      .hasText(
+        "from-custom-owner",
+        "the snippet's getOwner(...) resolved through the owner passed via formatOptions",
+      );
+  });
+});
+
 module("All Links", function (hooks) {
   setupApplicationTest(hooks);
 
@@ -59,6 +76,7 @@ module("All Links", function (hooks) {
       "/my-folder-name/bar.md",
       "/my-folder-name/baz",
       "/my-folder-name/foo",
+      "/my-folder-name/owner-probe.md",
     ]);
   });
 });


### PR DESCRIPTION
`setupKolay` spreads userland options into the docs service, but `setup()` picks a fixed set of option names and builds the compiler options internally — so repl-sdk's supported per-format options (`gjs`, `gmd`, `hbs`, `md`, …) can't be supplied from an app. The one we need is a custom `owner` for rendered snippets: ember-repl already defaults each format's `owner` and spreads user entries over it (`gjs: { owner, ...(options.gjs ?? {}) }`), so the only missing link is kolay forwarding them.

This adds a `formatOptions` option to `setup()` (and the `kolay/setup` types), keyed by format. Entries merge over the options kolay configures for each format:

```js
await setupKolay(this, {
  formatOptions: {
    gjs: { owner: myOwner },
    gmd: { owner: myOwner },
  },
});
```

Formats kolay doesn't configure (like `gjs`) pass straight through; for `md`/`gmd`/`hbs` the user's entries win key-by-key over kolay's. The JSDoc steers plugin additions to the existing `remarkPlugins`/`rehypePlugins` options so kolay's own plugins (frontmatter, link rebasing) aren't accidentally replaced.

## Testing

Integration test in `markdown-and-gjs-md-app`: the application route injects a probe owner via `formatOptions`, and a live `gjs` snippet on a runtime-compiled page asserts `getOwner(this).lookup(...)` resolves through it. (The probe page is plain `.md` on purpose — `.gjs.md` pages compile at build time and never consult the runtime compiler.)

All five test-apps pass, `pnpm lint` clean.

## Motivation

Our docs app needs to hand rendered snippets an owner that can answer environment-scoped lookups (the `ember-provide-consume-context` interaction described in https://github.com/customerio/ember-provide-consume-context/issues/58 — providers register on the snippet island's Environment while consumer reads resolve through the host app's renderer). This passthrough is the supported surface for that kind of customization; discussed with @NullVoxPopuli.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**AI attribution:** drafted by Claude Code (Fable 5), directed by @adrianbw; the approach (forwarding per-format options through `setup()`) is per NullVoxPopuli's guidance. Tested as described above; reviewed by the author before opening.
